### PR TITLE
Use content-id for signatures

### DIFF
--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -1,4 +1,4 @@
-import { toLetter } from '.'
+import { Letter } from '.'
 import { stateInfo, sampleMethod } from './router'
 import { implementedStates } from '../../common'
 
@@ -10,7 +10,7 @@ test('Leter for all states render correctly', async () => {
   const letters = await Promise.all(implementedStates.map(async state => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const info = await stateInfo(state)
-    return toLetter(
+    return new Letter(
       info,
       sampleMethod,
       confirmationId
@@ -18,11 +18,11 @@ test('Leter for all states render correctly', async () => {
   }))
 
   letters.forEach(letter => {
-    expect(letter?.md).toContain(confirmationId)
+    expect(letter?.md('html')).toContain(confirmationId)
     /*
       A poor man's test for missing fields
       since most fields are '**{{field}}**'
     */
-    expect(letter?.md).not.toContain('****')
+    expect(letter?.md('html')).not.toContain('****')
   })
 })

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -4,13 +4,14 @@ import nunjucks from 'nunjucks'
 import { processEnvOrThrow, StateInfo, ContactMethod, ImplementedState } from '../../common'
 import { fillNewHampshire } from '../pdfForm'
 import { fillNorthCarolina } from '../pdfForm'
+import { makeImageAttachment } from '../mg'
 
 nunjucks.configure(__dirname + '/views', {
   autoescape: true,
   noCache: !!process.env.NUNJUNKS_DISABLE_CACHE
 })
 
-interface Options { 
+interface Options {
   signature?: string
   idPhoto?: string
   form?: Buffer
@@ -97,7 +98,13 @@ export const toLetter = async (
         ...envVars,
         confirmationId,
         method,
-        warning: !process.env.EMAIL_FAX_OFFICIALS
+        warning: !process.env.EMAIL_FAX_OFFICIALS,
+        signatureFile: info.signature
+          ? makeImageAttachment(info.signature, 'signature', '')[0].filename
+          : undefined,
+        idPhotoFile: info.idPhoto
+          ? makeImageAttachment(info.idPhoto, 'identification', '')[0].filename
+          : undefined,
       }
     ),
     method,

--- a/packages/server/src/service/letter/router.ts
+++ b/packages/server/src/service/letter/router.ts
@@ -3,7 +3,7 @@ import { Router} from 'express'
 import { getContact, getFirstContact, getContactRecords } from '../contact'
 import { toContactMethod, StateInfo, ImplementedState, implementedStates, BaseInfo, ContactMethod, isImplementedState } from '../../common'
 import fs from 'fs'
-import { toLetter } from '.'
+import { Letter } from '.'
 
 
 export const router = Router()
@@ -46,7 +46,7 @@ export const stateInfo = async (state: ImplementedState): Promise<StateInfo> => 
     ...baseStateInfo,
     contact: await getFirstContact(state)
   }
-  
+
   switch(state) {
     case 'Wisconsin': return {
       ...commonStateInfo,
@@ -129,6 +129,6 @@ router.get('/:state/:key?', async (req, res) => {
 
   if (!method) return renderLetter('Could not find contact method for elections official')
 
-  const letter = await toLetter(info, method, confirmationId)
-  return renderLetter(letter.html)
+  const letter = new Letter(info, method, confirmationId)
+  return renderLetter(letter.render('html'))
 })

--- a/packages/server/src/service/letter/views/Base.md
+++ b/packages/server/src/service/letter/views/Base.md
@@ -20,7 +20,7 @@ Sincerely,
 
 {{name}}{% if signature %} (Signature Below and Attached)
 
-<img style='max-width: 400px;' src='{{signature}}'/>
+<img style='max-width: 400px;' src='cid:{{signatureFile}}'/>
 {% endif %}
 
 <font style='font-size:75%;'>

--- a/packages/server/src/service/letter/views/Base.md
+++ b/packages/server/src/service/letter/views/Base.md
@@ -20,7 +20,7 @@ Sincerely,
 
 {{name}}{% if signature %} (Signature Below and Attached)
 
-<img style='max-width: 400px;' src='cid:{{signatureFile}}'/>
+<img style='max-width: 400px;' src='{{signature}}'/>
 {% endif %}
 
 <font style='font-size:75%;'>

--- a/packages/server/src/service/mg.test.ts
+++ b/packages/server/src/service/mg.test.ts
@@ -1,7 +1,7 @@
 import { createMock } from 'ts-auto-mock'
 
 import { FloridaInfo, MichiganInfo, StateInfo, GeorgiaInfo, WisconsinInfo, ContactMethod } from "../common"
-import { toLetter } from './letter'
+import { Letter } from './letter'
 import { toSignupEmailData } from './mg'
 
 const email = 'email@example.com'
@@ -12,11 +12,11 @@ const check = async (info: StateInfo, checkSignature = false): Promise<void> => 
     emails: ['official@elections.gov'],
     faxes: [],
   }
-  
+
   const officialsEmails = sampleMethod.emails
   const confirmationId = 'abc123'
-  
-  const letter = await toLetter(info, sampleMethod, confirmationId)
+
+  const letter = new Letter(info, sampleMethod, confirmationId)
   expect(letter).toBeTruthy()
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -24,7 +24,7 @@ const check = async (info: StateInfo, checkSignature = false): Promise<void> => 
   expect(emailDataProd.to.length).toBeGreaterThanOrEqual(2)
   expect(emailDataProd.to).toContain(email)
   expect(emailDataProd.html).toContain(confirmationId)
-  
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const emailData = toSignupEmailData(letter!, info.email, officialsEmails)
   expect(emailData.to).toEqual([email])

--- a/packages/server/src/service/mg.ts
+++ b/packages/server/src/service/mg.ts
@@ -3,13 +3,12 @@ import mailgun from 'mailgun-js'
 import { Letter } from './letter'
 import { processEnvOrThrow } from '../common'
 
-
 export const mg = mailgun({
   domain: processEnvOrThrow('MG_DOMAIN'),
   apiKey: processEnvOrThrow('MG_API_KEY'),
 })
 
-const makeImageAttachment = (
+export const makeImageAttachment = (
   image: string,
   filename: string,  // without file extension
   to: string,        // just for error reporting
@@ -58,6 +57,7 @@ export const toSignupEmailData = (
     html,
     text: md,
     attachment,
+    inline: attachment,
     ...mgData,
   }
 }

--- a/packages/server/src/service/trpc.ts
+++ b/packages/server/src/service/trpc.ts
@@ -8,7 +8,7 @@ import { toContact, getContactRecords, getContact as _getContact } from './conta
 import { geocode } from './gm'
 import { toPdfBuffer } from './pdf'
 import { storageFileFromId } from './storage'
-import { toLetter } from './letter'
+import { Letter } from './letter'
 import { sendFaxes } from './twilio'
 import { TwilioResponse } from './types'
 
@@ -81,8 +81,8 @@ export class VbmRpc implements ImplRpc<IVbmRpc, Request> {
     })
 
     return data(id, async (): Promise<void> => {
-      const letter = await toLetter(info, method, id)
-      const pdfBuffer = await toPdfBuffer(letter.html, letter.form)
+      const letter = new Letter(info, method, id)
+      const pdfBuffer = await toPdfBuffer(letter.render('html'), await letter.form)
 
       // Send email (perhaps only to voter)
       const mgResponse = await sendSignupEmail(


### PR DESCRIPTION
- [x] It works on both Gmail and Outlook;
- [x] It works on both jpeg and png;
- [x] Works on cases where both an id photo and signature are present, i.e. first time registering for Nevada;
- [x] Fix tests;
- [x] Test if it works on Faxes;

https://lu-vbm.ludanin.vercel.app

Cheers!