### PR TITLE
Add translation dropdown

### DIFF
--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -148,31 +148,34 @@ const LocaleToggle = styled.div<NavExpanded>`
   --rowWidth: 170px;
   --rowHeight: 50px;
   overflow: visible;
-  position: relative;
 
   /* Keeps as the last item on Navbar */
   ${cssQuery.large} { order: 2; }
+
+  /* Clears Toggle animation */
+  button i {
+    color: #2196f3 !important;
+    transform: none !important;
+  }
 
   .picker {
     width: var(--rowWidth);
 
     position: fixed;
-    top: 0;
-    /* We use margin instead of top so the sliding animation works */
-    margin-top: calc(var(--height) * 1.15);
+    /* Creates the effect that the dropdown is touching/merged with the navbar */
+    top: calc(var(--height) * 0.97);
     margin-left: calc(var(--rowWidth) / -2.78);
     ${cssQuery.large} { margin-left: calc(var(--rowWidth) / -3); }
 
     background-color: #fff;
-    border-radius: 4px;
+    box-shadow: 0 6px 7px rgba(0, 0, 0, 0.05);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
 
-    animation: ${
-      p => p.expanded
-      ? css`${slideDown} ease .4s both`
-      : css`${slideUp} ease .2s both`
-    };
+    transform: scaleY(${p => p.expanded ? 1 : 0});
+    transform-origin: top;
     opacity: ${p => p.expanded ? '1' : '0'};
-    transition: opacity ease .2s;
+    transition: opacity ease .3s, transform ease .15s;
     pointer-events: ${p => p.expanded ? 'initial' : 'none'};
 
     button {
@@ -181,6 +184,7 @@ const LocaleToggle = styled.div<NavExpanded>`
       /* MuiCSS Buttons have predefined margins/paddings */
       padding: 0; margin: 0;
 
+      font-size: 12px;
       font-weight: bold;
 
       box-sizing: border-box;
@@ -190,6 +194,17 @@ const LocaleToggle = styled.div<NavExpanded>`
       button { border-bottom: none; }
     }
   }
+`
+
+const DismissDropdown = styled.div<NavExpanded>`
+  display: ${p => p.expanded ? 'block' : 'none'};
+  position: absolute;
+  width: 100%;
+  /* So users can still click on the navbar links */
+  height: calc(100vh - var(--height));
+  top: var(--height);
+  left: 0;
+  z-index: -2;
 `
 
 const NavLinks = styled.div<NavExpanded>`
@@ -300,11 +315,12 @@ export const Navbar = () => {
         <img src={logo} alt='VoteByMail'/>
     </Logo>
     <LocaleToggle expanded={localesExpanded}>
+      <DismissDropdown expanded={localesExpanded} onClick={toggleLocalesExpanded}/>
       <NavToggleButton onClick={toggleLocalesExpanded} expanded={localesExpanded} variant='flat'>
-      <i className={`fa ${localesExpanded ? 'fa-close' : 'fa-globe'}`}/>
+        <i className='fa fa-globe'/>
       </NavToggleButton>
       {/* Top 5 non-English languages, in order https://en.wikipedia.org/wiki/Languages_of_the_United_States#Most_common_languages */}
-      <div className='picker mui--z3' onClick={toggleLocalesExpanded}>
+      <div className='picker mui--z0' onClick={toggleLocalesExpanded}>
         <a href={`https://translate.google.com/translate?hl=&sl=en&tl=es&u=${url}`}>
           <Button translate='no' variant='flat'>Espa&ntilde;ol</Button>
         </a>

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -300,30 +300,31 @@ export const Navbar = () => {
         <img src={logo} alt='VoteByMail'/>
     </Logo>
     <LocaleToggle expanded={localesExpanded}>
-      <NavToggleButton onClick={toggleLocalesExpanded} expanded={localesExpanded} variant="flat">
+      <NavToggleButton onClick={toggleLocalesExpanded} expanded={localesExpanded} variant='flat'>
       <i className={`fa ${localesExpanded ? 'fa-close' : 'fa-globe'}`}/>
       </NavToggleButton>
-      <div className="picker mui--z3" onClick={toggleLocalesExpanded}>
+      {/* Top 5 non-English languages, in order https://en.wikipedia.org/wiki/Languages_of_the_United_States#Most_common_languages */}
+      <div className='picker mui--z3' onClick={toggleLocalesExpanded}>
+        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=es&u=${url}`}>
+          <Button translate='no' variant='flat'>Espa&ntilde;ol</Button>
+        </a>
         <a href={`https://translate.google.com/translate?hl=&sl=en&tl=zh-CN&u=${url}`}>
-          <Button variant="flat">
+          <Button translate='no' variant='flat'>{'\u7b80\u4f53\u4e2d\u6587'}</Button>
+        </a>
+        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=tl&u=${url}`}>
+          <Button translate='no' variant='flat'>Filipino</Button>
+        </a>
+        <a href={`https://translate.google.com/translate?sl=en&tl=vi&u=${url}`}>
+          <Button translate='no' variant='flat'>Ti{'\u1ebf'}ng Vi{'\u1ec7'}t</Button>
+        </a>
+        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=ar&u=${url}`}>
+          <Button translate='no' variant='flat'>
             {'\u0627\u0644\u0639\u0631\u0628\u064a\u0629'}
           </Button>
         </a>
-        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=zh-CN&u=${url}`}>
-          <Button variant="flat">{'\u7b80\u4f53\u4e2d\u6587'}</Button>
-        </a>
-        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=es&u=${url}`}>
-          <Button variant="flat">Espa&ntilde;ol</Button>
-        </a>
-        <a href={`https://translate.google.com/translate?hl=&sl=en&tl=tl&u=${url}`}>
-          <Button variant="flat">Filipino</Button>
-        </a>
-        <a href={`https://translate.google.com/translate?sl=en&tl=vi&u=${url}`}>
-          <Button variant="flat">Ti{'\u1ebf'}ng Vi{'\u1ec7'}t</Button>
-        </a>
       </div>
     </LocaleToggle>
-    <NavLinksToggle onClick={toggleLinksExpanded} expanded={linksExpanded} variant="flat">
+    <NavLinksToggle onClick={toggleLinksExpanded} expanded={linksExpanded} variant='flat'>
       <i className={`fa ${linksExpanded ? 'fa-close' : 'fa-navicon'}`}/>
     </NavLinksToggle>
     <NavLinks expanded={linksExpanded}>

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -155,7 +155,14 @@ const LocaleToggle = styled.div<NavExpanded>`
   /* Clears Toggle animation */
   button i {
     color: #2196f3 !important;
-    transform: none !important;
+    margin-left: 2px;
+    &.static {
+      transform: none !important;
+    }
+    &.chevron {
+      font-size: 8px;
+      transform: rotate(${p => p.expanded ? '-180deg' : '0'});
+    }
   }
 
   .picker {
@@ -165,7 +172,7 @@ const LocaleToggle = styled.div<NavExpanded>`
     /* Creates the effect that the dropdown is touching/merged with the navbar */
     top: calc(var(--height) * 0.97);
     margin-left: calc(var(--rowWidth) / -2.78);
-    ${cssQuery.large} { margin-left: calc(var(--rowWidth) / -2.5); }
+    ${cssQuery.large} { margin-left: calc(var(--rowWidth) / -2.4); }
 
     background-color: #fff;
     box-shadow: 0 6px 7px rgba(0, 0, 0, 0.05);
@@ -313,12 +320,13 @@ export const Navbar = () => {
   // might not have the appropriate fonts for all these locales).
   return <Wrapper expanded={linksExpanded} visible={visible}>
     <Logo to='#' onClick={() => pushAndClose('start')}>
-        <img src={logo} alt='VoteByMail'/>
+      <img src={logo} alt='VoteByMail'/>
     </Logo>
     <LocaleToggle expanded={localesExpanded}>
       <DismissDropdown expanded={localesExpanded} onClick={toggleLocalesExpanded}/>
       <NavToggleButton onClick={toggleLocalesExpanded} expanded={localesExpanded} variant='flat'>
-        <i className='fa fa-globe'/>
+        <i className="fa fa-globe static"/>
+        <i className="fa fa-chevron-down chevron"/>
       </NavToggleButton>
       {/* Top 5 non-English languages, in order https://en.wikipedia.org/wiki/Languages_of_the_United_States#Most_common_languages */}
       <div className='picker mui--z0' onClick={toggleLocalesExpanded}>

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -10,7 +10,7 @@ import { processEnvOrThrow } from '../common'
 
 
 interface NavExpanded {
-  expanded: 'translation' | 'links' | ''
+  expanded: 'translation' | 'links' | null
 }
 
 const fadeIn = keyframes`
@@ -276,7 +276,7 @@ const NavLinks = styled.div<NavExpanded>`
 
 export const Navbar = () => {
   const { pushStartSection } = useAppHistory()
-  const [expanded, setExpanded] = React.useState<NavExpanded['expanded']>('')
+  const [expanded, setExpanded] = React.useState<NavExpanded['expanded']>(null)
   const [visible, setVisibility] = React.useState(true)
   const [scrollY, setScrollY] = React.useState(window.pageYOffset)
 
@@ -291,7 +291,7 @@ export const Navbar = () => {
         if (window.pageYOffset > scrollY) {
           setVisibility(false)
           if (expanded) {
-            setExpanded('')
+            setExpanded(null)
           }
         }
       }
@@ -301,7 +301,7 @@ export const Navbar = () => {
 
   const toggleExpanded = (target: 'links' | 'translation') => {
     if (expanded === target) {
-      setExpanded('')
+      setExpanded(null)
     } else {
       setExpanded(target)
     }
@@ -311,7 +311,7 @@ export const Navbar = () => {
   // clicks on a link
   const pushAndClose = (section: StartSectionPath['type']) => {
     pushStartSection(section)
-    if (expanded) setExpanded('')
+    if (expanded) setExpanded(null)
   }
 
   const url = encodeURI(processEnvOrThrow('REACT_APP_URL'))
@@ -325,7 +325,7 @@ export const Navbar = () => {
     </Logo>
     <DismissDropdown
       expanded={expanded}
-      onClick={() => setExpanded('')}
+      onClick={() => setExpanded(null)}
     />
     <LocaleToggle expanded={expanded}>
       <NavToggleButton

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -175,7 +175,7 @@ const LocaleToggle = styled.div<NavExpanded>`
     transform: scaleY(${p => p.expanded ? 1 : 0});
     transform-origin: top;
     opacity: ${p => p.expanded ? '1' : '0'};
-    transition: opacity ease .3s, transform ease .15s;
+    transition: opacity ease .15s, transform ease .2s;
     pointer-events: ${p => p.expanded ? 'initial' : 'none'};
 
     button {

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -219,6 +219,7 @@ const NavLinks = styled.div<NavExpanded>`
   box-shadow: 0 4px 3px rgba(0, 0, 0, 0.05) inset;
   /* Makes the shadow (of the navlinks) ignore the Wrapper horizontal padding */
   margin: 0 -10%;
+  ${cssQuery.small} { margin-top: 4px; }
   animation: ${fadeIn} ease .5s .3s both;
 
   /* When animating, doesn't let the content be drawn on top of the logo/toggle button */

--- a/packages/client/src/comp/Navbar.tsx
+++ b/packages/client/src/comp/Navbar.tsx
@@ -114,8 +114,8 @@ const NavToggleButton = styled(Button)<Partial<NavExpanded>>`
   --wrapperSize: var(--contentHeight);
   --iconSize: calc(var(--wrapperSize) * 0.35);
   ${cssQuery.large} {
-    --wrapperSize: calc(var(--contentHeight) * 0.7);
-    --iconSize: calc(var(--wrapperSize) * 0.4);
+    --wrapperSize: 28px;
+    --iconSize: 16px;
   }
 
   /* In order to make the Material Ripple a perfect circle */
@@ -165,7 +165,7 @@ const LocaleToggle = styled.div<NavExpanded>`
     /* Creates the effect that the dropdown is touching/merged with the navbar */
     top: calc(var(--height) * 0.97);
     margin-left: calc(var(--rowWidth) / -2.78);
-    ${cssQuery.large} { margin-left: calc(var(--rowWidth) / -3); }
+    ${cssQuery.large} { margin-left: calc(var(--rowWidth) / -2.5); }
 
     background-color: #fff;
     box-shadow: 0 6px 7px rgba(0, 0, 0, 0.05);
@@ -229,8 +229,8 @@ const NavLinks = styled.div<NavExpanded>`
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
-  /* Without this 5px on top the links are going to be offsetted upwards */
-  padding-top: 5px;
+  /* Without this 2px on top the links are going to be offsetted upwards */
+  padding-top: 2px;
 
   /*
     These devices have enough space to show all the links in one single row.


### PR DESCRIPTION
- [x] Creates a picker which allows users to choose among the top 5 foreign languages in the USA;
- [x] Decide between using the current translation icon or a globe (both are widely used across the web);

Note: this PR is based on top of the changes implemented on redesign #4 

https://lu-vbm-akbwa6rle.vercel.app/