### PR TITLE
add an ENV variable to ignore the env file

### DIFF
--- a/env/env.js
+++ b/env/env.js
@@ -1,4 +1,6 @@
 // Based on https://www.npmjs.com/package/env-cmd
+if (process.env.IGNORE_ENV_FILE) { return; }
+
 const {
   MG_API_KEY,
   TWILIO_SID,


### PR DESCRIPTION
this is so Vercel can use its own configured environment variables when generating a preview deploy and not get tripped up by files that are gitignored