### PR TITLE
Fix unsafe fs.readFile calls

### DIFF
--- a/packages/server/src/service/letter/router.ts
+++ b/packages/server/src/service/letter/router.ts
@@ -2,14 +2,14 @@ import { Router} from 'express'
 
 import { getContact, getFirstContact, getContactRecords } from '../contact'
 import { toContactMethod, StateInfo, ImplementedState, implementedStates, BaseInfo, ContactMethod, isImplementedState } from '../../common'
-import fs from 'fs'
 import { Letter } from '.'
+import { safeReadFileSync } from '../util'
 
 
 export const router = Router()
 
 const loadBase64 = (filename: string) => {
-  return fs.readFileSync(__dirname + '/' + filename).toString('base64')
+  return Buffer.from(safeReadFileSync(__dirname + '/' + filename)).toString('base64')
 }
 
 const baseStateInfo: Omit<BaseInfo, 'contact'> = {

--- a/packages/server/src/service/letter/router.ts
+++ b/packages/server/src/service/letter/router.ts
@@ -9,7 +9,7 @@ import { safeReadFileSync } from '../util'
 export const router = Router()
 
 const loadBase64 = (filename: string) => {
-  return Buffer.from(safeReadFileSync(__dirname + '/' + filename)).toString('base64')
+  return safeReadFileSync(__dirname + '/' + filename).toString('base64')
 }
 
 const baseStateInfo: Omit<BaseInfo, 'contact'> = {

--- a/packages/server/src/service/pdfForm/index.ts
+++ b/packages/server/src/service/pdfForm/index.ts
@@ -1,5 +1,5 @@
 import { PDFDocument, StandardFonts, rgb, PDFPage, PDFPageDrawTextOptions } from 'pdf-lib'
-import fs from 'fs'
+import { safeReadFile } from '../util'
 
 export { fillNorthCarolina } from './northCarolina'
 export { fillNewHampshire } from './newHampshire'
@@ -14,23 +14,11 @@ interface FillFormArg {
   placeImage: (imageBuffer: Uint8Array, page: number, x: number, y: number) => Promise<void>
 }
 
-/**
- * Need to make Uint8Array right away because buffer is reused
- * https://github.com/nodejs/node/issues/11132#issuecomment-277157700
- * */
-export const readBinaryFile = (filename: string): Promise<Uint8Array> => {
-  return new Promise((resolve, reject) => {
-    fs.readFile(filename, (err, data) => {
-      err ? reject(err) : resolve(new Uint8Array(data.buffer))
-    })
-  })
-}
-
 export const fillFormWrapper = async (
   filename: string,
   fillForm: (arg: FillFormArg) => Promise<void>,
 ): Promise<Buffer> => {
-  const byteArray = await readBinaryFile(filename)
+  const byteArray = await safeReadFile(filename)
   const doc = await PDFDocument.load(byteArray)
   const options = {
     font: await doc.embedFont(StandardFonts.Helvetica),

--- a/packages/server/src/service/pdfForm/index.ts
+++ b/packages/server/src/service/pdfForm/index.ts
@@ -19,7 +19,7 @@ export const fillFormWrapper = async (
   fillForm: (arg: FillFormArg) => Promise<void>,
 ): Promise<Buffer> => {
   const byteArray = await safeReadFile(filename)
-  const doc = await PDFDocument.load(byteArray)
+  const doc = await PDFDocument.load(byteArray.toString('base64'))
   const options = {
     font: await doc.embedFont(StandardFonts.Helvetica),
     size: 12,

--- a/packages/server/src/service/storage.proto.ts
+++ b/packages/server/src/service/storage.proto.ts
@@ -4,7 +4,7 @@ import { safeReadFile } from './util'
 const main = async () => {
   const buffer = await safeReadFile(__dirname + '/test/test.pdf')
   const file = new StorageFile('test/test.pdf')
-  const result = await file.upload(buffer.toString('utf-8'))
+  const result = await file.upload(buffer)
   console.log(result)
   const reuslt2 = await file.getSignedUrl(24 * 60 * 60 * 1000)
   console.log(reuslt2)

--- a/packages/server/src/service/storage.proto.ts
+++ b/packages/server/src/service/storage.proto.ts
@@ -1,10 +1,10 @@
 import { StorageFile } from './storage'
-import { safeReadFile, uint8ToString } from './util'
+import { safeReadFile } from './util'
 
 const main = async () => {
   const buffer = await safeReadFile(__dirname + '/test/test.pdf')
   const file = new StorageFile('test/test.pdf')
-  const result = await file.upload(uint8ToString(buffer))
+  const result = await file.upload(buffer.toString('utf-8'))
   console.log(result)
   const reuslt2 = await file.getSignedUrl(24 * 60 * 60 * 1000)
   console.log(reuslt2)

--- a/packages/server/src/service/storage.proto.ts
+++ b/packages/server/src/service/storage.proto.ts
@@ -1,10 +1,10 @@
 import { StorageFile } from './storage'
-import fs from 'fs'
+import { safeReadFile, uint8ToString } from './util'
 
 const main = async () => {
-  const buffer = fs.readFileSync(__dirname + '/test/test.pdf')
+  const buffer = await safeReadFile(__dirname + '/test/test.pdf')
   const file = new StorageFile('test/test.pdf')
-  const result = await file.upload(buffer)
+  const result = await file.upload(uint8ToString(buffer))
   console.log(result)
   const reuslt2 = await file.getSignedUrl(24 * 60 * 60 * 1000)
   console.log(reuslt2)

--- a/packages/server/src/service/util.ts
+++ b/packages/server/src/service/util.ts
@@ -9,6 +9,14 @@ interface Options{
 type AsyncFunc<A extends unknown[], R> = (...args: A) => Promise<R>
 
 /**
+ * Utility to copy buffer for shared ArrayBuffer issue
+ * https://github.com/nodejs/node/issues/11132#issuecomment-277157700
+ */
+const copyBuffer = (buffer: Buffer): Buffer => Buffer.from(
+  new Uint8Array(buffer).buffer
+)
+
+/**
  * Asynchronously reads the entire contents of a file.
  *
  * @param path A path to a file. If a URL is provided, it must use the
@@ -23,7 +31,7 @@ export const safeReadFile = (
   options?: { encoding?: null | undefined, flag?: string | undefined },
 ) => new Promise<Buffer>((resolve, reject) => {
   fs.readFile(path, options, (err, data) => {
-    err ? reject(err) : resolve(Buffer.from(new Uint8Array(data).buffer))
+    err ? reject(err) : resolve(copyBuffer(data))
   })
 })
 
@@ -40,7 +48,7 @@ export const safeReadFile = (
 export const safeReadFileSync = (
   path: fs.PathLike | number,
   options?: { encoding?: null | undefined, flag?: string | undefined },
-) => Buffer.from(new Uint8Array(fs.readFileSync(path, options)).buffer)
+) => copyBuffer(fs.readFileSync(path, options))
 
 export const cache = <A extends unknown[], R>(
   func: AsyncFunc<A, R>,

--- a/packages/server/src/service/util.ts
+++ b/packages/server/src/service/util.ts
@@ -18,8 +18,8 @@ type AsyncFunc<A extends unknown[], R> = (...args: A) => Promise<R>
  * @param options An object that may contain an optional flag. If a flag
  * is not provided, it defaults to 'r'.
  */
-export const safeReadFile = async (
-  path: fs.PathLike | number,
+export const safeReadFile = (
+  path: fs.PathLike,
   options?: { encoding?: null | undefined, flag?: string | undefined },
 ) => new Promise<Buffer>((resolve, reject) => {
   fs.readFile(path, options, (err, data) => {

--- a/packages/server/src/service/util.ts
+++ b/packages/server/src/service/util.ts
@@ -8,6 +8,46 @@ interface Options{
 }
 type AsyncFunc<A extends unknown[], R> = (...args: A) => Promise<R>
 
+/**
+ * Asynchronously reads the entire contents of a file.
+ *
+ * @param path A path to a file. If a URL is provided, it must use the
+ * file: protocol. If a file descriptor is provided, the underlying file
+ * will not be closed automatically.
+ *
+ * @param options An object that may contain an optional flag. If a flag
+ * is not provided, it defaults to 'r'.
+ */
+export const safeReadFile = async (
+  path: fs.PathLike | number,
+  options?: { encoding?: null | undefined, flag?: string | undefined },
+) => new Promise<Uint8Array>((resolve, reject) => {
+  fs.readFile(path, options, (err, data) => {
+    err ? reject(err) : resolve(new Uint8Array(data.buffer))
+  })
+})
+
+/**
+ * Reads the entire contents of a file.
+ *
+ * @param path A path to a file. If a URL is provided, it must use the
+ * file: protocol. If a file descriptor is provided, the underlying file
+ * will not be closed automatically.
+ *
+ * @param options An object that may contain an optional flag. If a flag
+ * is not provided, it defaults to 'r'.
+ */
+export const safeReadFileSync = (
+  path: fs.PathLike | number,
+  options?: { encoding?: null | undefined, flag?: string | undefined },
+) => new Uint8Array(fs.readFileSync(path, options))
+
+/**
+ * Converts an Uint8Array to a 'utf-8' string.
+ * @param source An Uint8Array to be converted
+ */
+export const uint8ToString = (source: Uint8Array) => new TextDecoder().decode(source)
+
 export const cache = <A extends unknown[], R>(
   func: AsyncFunc<A, R>,
   namer: AsyncFunc<A, string>,

--- a/packages/server/src/service/util.ts
+++ b/packages/server/src/service/util.ts
@@ -21,9 +21,9 @@ type AsyncFunc<A extends unknown[], R> = (...args: A) => Promise<R>
 export const safeReadFile = async (
   path: fs.PathLike | number,
   options?: { encoding?: null | undefined, flag?: string | undefined },
-) => new Promise<Uint8Array>((resolve, reject) => {
+) => new Promise<Buffer>((resolve, reject) => {
   fs.readFile(path, options, (err, data) => {
-    err ? reject(err) : resolve(new Uint8Array(data.buffer))
+    err ? reject(err) : resolve(Buffer.from(new Uint8Array(data).buffer))
   })
 })
 
@@ -40,13 +40,7 @@ export const safeReadFile = async (
 export const safeReadFileSync = (
   path: fs.PathLike | number,
   options?: { encoding?: null | undefined, flag?: string | undefined },
-) => new Uint8Array(fs.readFileSync(path, options))
-
-/**
- * Converts an Uint8Array to a 'utf-8' string.
- * @param source An Uint8Array to be converted
- */
-export const uint8ToString = (source: Uint8Array) => new TextDecoder().decode(source)
+) => Buffer.from(new Uint8Array(fs.readFileSync(path, options)).buffer)
 
 export const cache = <A extends unknown[], R>(
   func: AsyncFunc<A, R>,


### PR DESCRIPTION
Had to convert the server gulpfile to TypeScript to make this work, the type assertions on `gulpfile.ts` are not optimal (there are some `any` over there) but for this fix that will be enough.