### PR TITLE
Change link to our own Michigan ArcGis server

### DIFF
--- a/packages/server/src/service/michiganFipsCode.ts
+++ b/packages/server/src/service/michiganFipsCode.ts
@@ -11,7 +11,7 @@ interface Response {
 
 const rawMichiganResponse = async (latLong: [number, number]): Promise<Response | null> => {
   const [lat, lng] = latLong
-  const url = `https://gisago.mcgi.state.mi.us/arcgis/rest/services/OpenData/michigan_geographic_framework/MapServer/2/query?where=1%3D1&geometry=${lng}%2C${lat}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=pjson`
+  const url = `https://services5.arcgis.com/AbZVanP1q8d5OLCX/arcgis/rest/services/vbm_michigan/FeatureServer/0/query?where=1%3D1&geometry=${lng}%2C${lat}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=pjson`
   try {
     return (await (await fetch(url)).json() as Response)
   } catch (error) {


### PR DESCRIPTION
All the work has been done on the ArcGis side, all we had to do in the code was to change the URL to point to our own server.

Here is the service:
https://developers.arcgis.com/layers/14d62b7abbc44192a0f306bb6cddf877

Here is an example of a GET call using the new server:
https://services5.arcgis.com/AbZVanP1q8d5OLCX/arcgis/rest/services/vbm_michigan/FeatureServer/0/query?where=1%3D1&geometry=-83.49005240000001%2C42.3288129&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=true&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentOnly=false&featureEncoding=esriDefault&f=pjson