### PR TITLE
Lets users subscribe to our newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Below are the settings that need to be set to get an environment to work.
 
 - **Mailgun**: You only need these to send emails (last step in signup flow).  It's easy to get set up for free.  Since you don't have access to our domain records, you will probabyl want to set your emails to be sent from the sanbox domain that mailgun sets up automatically when you sign up.
 
+- **SendinBlue**: We use [SendinBlue](https://www.sendinblue.com/) for our newsletter.  Sign up for an account and grab your V3 API key [here](https://account.sendinblue.com/advanced/api).
+
 - **Twilio**: You only need these to send faxes (last step in signup flow).  It's easy to get set up for free.
 
 - **Incoming fax numbers**: To test Twilio, we setup an incoming fax number.  ([FaxBurner](https://www.faxburner.com/)) offers a free temporary one.  Set `RECEIVE_FAX_NUMBER` to this number.
@@ -163,6 +165,7 @@ For every environment (e.g. development, staging, production),
 - Make sure that the right environment variables are set for the right environment (e.g. staging `GCLOUD_PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` are set for staging and not production).
 - Sign up for `default` org landing page
 - Test email API using `mg.proto.ts`
+- Test newsletter signup API using `sendinblue.proto.ts`
 - Test fax using `twillio.proto.ts`.  You need to set a valid incoming fax number for testing
 - Test geocoding and Google Maps using `gm.proto.ts`.  Try an address in Michigan (for which there are separate rules) and
 - Test pdf generation using `pdf.proto.ts`

--- a/env/env.js
+++ b/env/env.js
@@ -7,6 +7,7 @@ const {
   TWILIO_TOKEN,
   TWILIO_FAX_NUMBER,
   RECEIVE_FAX_NUMBER,
+  SENDINBLUE_API_KEY,
   STAGING,
   DEV,
   PROD,
@@ -28,6 +29,8 @@ const base = removeNullValues({
   TWILIO_TOKEN,
   TWILIO_FAX_NUMBER,
   RECEIVE_FAX_NUMBER,
+  SENDINBLUE_API_KEY,
+  SENDINBLUE_LIST_ID: 4,  // This is just a fake testing list -- no emails will be sent
   USER_MAX_ORGS: 15,
   REACT_APP_BRAND_NAME: 'VoteByMail.io',
   REACT_APP_URL: 'https://votebymail.io/',
@@ -96,6 +99,7 @@ const production = removeNullValues({
   GCLOUD_PROJECT: 'vbm-prod-281822',
   GOOGLE_APPLICATION_CREDENTIALS: './secrets/vbm-prod-281822-9e04d7cdeb71.json',
   REACT_APP_GOOGLE_UA: 'UA-171601425-1',
+  SENDINBLUE_LIST_ID: 3,  // This is the real list
   REACT_APP_BRAND_NAME: 'VoteByMail.io',
   REACT_APP_URL: 'https://votebymail.io/',
   FIRESTORE_URL: 'https://vbm-prod-281822.firebaseio.com',

--- a/env/secrets.sample.json
+++ b/env/secrets.sample.json
@@ -6,6 +6,7 @@
   "RECEIVE_FAX_NUMBER": "xxx",
   "GOOGLE_CLIENT_ID": "xxx",
   "GOOGLE_CLIENT_SECRET": "xxx",
+  "SENDINBLUE_API_KEY": "xxx",
   "DEV": {
     "GOOGLE_CLIENT_ID": "xxx",
     "GOOGLE_CLIENT_SECRET": "xxx",

--- a/packages/client/src/comp/Footer.tsx
+++ b/packages/client/src/comp/Footer.tsx
@@ -6,6 +6,9 @@ import { cssQuery } from './util/cssQuery'
 import { InputButton } from './util/InputButton'
 import { Container, Button } from 'muicss/react'
 import { MarketingWrapper } from './util/MarketingWrapper'
+import { FetchingDataContainer } from '../lib/unstated'
+import { toast } from 'react-toastify'
+import { client } from '../lib/trpc'
 
 const FooterWrapper  = styled(MarketingWrapper)`
   box-shadow: 0 12px 14px -10px rgba(0, 0, 0, 0.15) inset;
@@ -133,9 +136,29 @@ const StyledInputButton = styled(InputButton)`
 `
 
 const Form: React.FC = () => {
-  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    // TODO subscribe users to our newsletter
-    console.log(e)
+  const { setFetchingData } = FetchingDataContainer.useContainer()
+  const emailRef = React.useRef<HTMLInputElement>(null)
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    e.persist()
+    setFetchingData(true)
+    if (emailRef.current) {
+      try {
+        await client.subscribe(emailRef?.current?.value)
+        emailRef.current.value = ''
+        toast(
+          'You are now subscribed to our newsletter.',
+          { type: 'success' },
+        )
+      } catch(e) {
+        toast(
+          'Failed to subscribe to our newsletter.  Please try again.',
+          { type: 'error' },
+        )
+      }
+    }
+    setFetchingData(false)
   }
 
   return <>
@@ -148,6 +171,7 @@ const Form: React.FC = () => {
       placeholder="Enter your email"
       onSubmit={onSubmit}
       buttonLabel="Enter"
+      ref={emailRef}
     />
   </>
 }

--- a/packages/common/trpc.ts
+++ b/packages/common/trpc.ts
@@ -18,5 +18,6 @@ export interface IVbmRpc extends IRpc<IVbmRpc> {
   fetchContacts(state: ImplementedState): Promise<RpcRet<string[]>>
   getContact(state: ImplementedState, key: string): Promise<RpcRet<ContactData>>
   contactUs(author: string, subject: string, text: string): Promise<RpcRet<boolean>>
+  subscribe(email: string): Promise<RpcRet<boolean>>
   register(info: StateInfo, voter: Voter): Promise<RpcRet<string>>
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -44,6 +44,7 @@
     "nodemon": "^1.19.1",
     "react-test-renderer": "^16.13.0",
     "serve": "^11.3.0",
+    "sib-api-v3-typescript": "^1.2.1",
     "supertest": "^4.0.0",
     "ts-auto-mock": "^1.6.0",
     "ts-jest": "^24.0.0",

--- a/packages/server/src/service/sendinblue.proto.ts
+++ b/packages/server/src/service/sendinblue.proto.ts
@@ -1,0 +1,37 @@
+import { sib } from './sendinblue'
+
+const dummy = 'dummy@example.com'
+
+const main = async () => {
+  // Adds user to list
+  console.log(`Adding ${dummy} to Sendinblue listId=${sib.listId}`)
+  try {
+    const success = await sib.addSubscriber(dummy)
+    if (!success) {
+      console.log(`Failed to add ${dummy}.`)
+      return
+    }
+    console.log(`Successfully added ${dummy}.`)
+  } catch(e) {
+    console.log(`Error when adding ${dummy}`)
+    console.error(e)
+    return
+  }
+
+  // Check user status on list
+  console.log(`Checking ${dummy} status on Sendinblue listId=${sib.listId}`)
+  try {
+    const response = await sib.getSubscriber(dummy)
+    const inList = (response?.body?.listIds?.indexOf(sib.listId) ?? -1) !== -1
+    if (!inList) {
+      console.log(`Apparently, ${dummy} is not on listId=${sib.listId}`)
+    } else {
+      console.log(`${dummy} is on listId=${sib.listId}`)
+    }
+  } catch(e) {
+    console.log(`Error when checking ${dummy} status`)
+    console.error(e)
+  }
+}
+
+main()

--- a/packages/server/src/service/sendinblue.ts
+++ b/packages/server/src/service/sendinblue.ts
@@ -1,0 +1,53 @@
+import { processEnvOrThrow } from '../common'
+import { ContactsApi, ContactsApiApiKeys } from 'sib-api-v3-typescript'
+
+// Configure Authentication & API
+
+const key = processEnvOrThrow('SENDINBLUE_API_KEY')
+const listId = () => {
+  const raw = processEnvOrThrow('SENDINBLUE_LIST_ID')
+  return Number.parseInt(raw , 10)
+}
+
+class Sendinblue {
+  private readonly contacts = new ContactsApi()
+
+  // Initializes API keys
+  constructor() {
+    this.contacts.setApiKey(ContactsApiApiKeys.apiKey, key)
+  }
+
+  // Since we use Contact for election officials, Sendinblue contacts are
+  // exported as subscribers to avoid confusion in the codebase
+
+  /** Exported for testing purposes */
+  public get listId() { return listId() }
+
+  /**
+   * Adds a new subscriber to VoteByMail newsletter, returns true if successful
+   */
+  public addSubscriber = async (email: string) => {
+    const response = await this.contacts.createContact({
+      email,
+      emailBlacklisted: false,
+      attributes: null,
+      listIds: [this.listId],
+      smsBlacklisted: true,
+      smtpBlacklistSender: [],
+      updateEnabled: true,
+    })
+    const statusCode = response?.response?.statusCode ?? 500
+
+    // https://developers.sendinblue.com/reference#createcontact
+    // When creating is 201, when updating (in case an user subscribes twice)
+    // it is 204
+    return statusCode === 201 || statusCode === 204
+  }
+
+  /**
+   * Returns the details of a subscriber
+   */
+  public getSubscriber = (email: string) => this.contacts.getContactInfo(email)
+}
+
+export const sib = new Sendinblue()

--- a/packages/server/src/service/trpc.ts
+++ b/packages/server/src/service/trpc.ts
@@ -11,6 +11,7 @@ import { storageFileFromId } from './storage'
 import { Letter } from './letter'
 import { sendFaxes } from './twilio'
 import { TwilioResponse } from './types'
+import { sib } from './sendinblue'
 
 const firestoreService = new FirestoreService()
 
@@ -80,6 +81,16 @@ export class VbmRpc implements ImplRpc<IVbmRpc, Request> {
         subject: `Submission from Contact Us (${authorName} ${authorEmail})`,
         text: text,
       })
+    } catch(e) {
+      console.error(e)
+      return e
+    }
+  }
+  public subscribe = async (email: string) => {
+    try {
+      const success = await sib.addSubscriber(email)
+      if (!success) throw(success)
+      return success
     } catch(e) {
       console.error(e)
       return e

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,6 +2963,11 @@
   dependencies:
     "@types/babel-types" "*"
 
+"@types/bluebird@*":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.32.tgz#381e7b59e39f010d20bbf7e044e48f5caf1ab620"
+  integrity sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==
+
 "@types/body-parser@*", "@types/body-parser@^1.19.0":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -3326,6 +3331,16 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/request@*":
+  version "2.48.5"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
+  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
 
 "@types/request@2.48.4":
   version "2.48.4"
@@ -4736,7 +4751,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -16352,6 +16367,16 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+sib-api-v3-typescript@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sib-api-v3-typescript/-/sib-api-v3-typescript-1.2.1.tgz#1b35c911a168eb308932d63cab2147542876a403"
+  integrity sha512-dfdLcmxUFauMAI6V+QYE2iMzd5NoxvpCuUE6Y50+C0KvVKcT6w8LqTbpv2LDlvaKVLjeM5yMKY6uuLU/IYQHSg==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/request" "*"
+    bluebird "^3.5.0"
+    request "^2.81.0"
 
 side-channel@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Some new env keys were added in this commit (`SENDINBLUE_API_KEY` and `SENDINBLUE_LIST_ID`).

- [x] Upon submission of form, call backend via trpc;
- [ ] Create a `sendingblue.ts` and `sendinblue.proto.ts` on the server (similar to mg.ts and mg.proto.ts is) and use a script to create a sendin blue contact using their API (I **haven't created** `sendinblue.proto.ts` yet, but our tests already adds contacts to the API);
- [x] Backend uses sendinblue API https://developers.sendinblue.com/docs/getting-started;
- [x] Prefer to use this library: https://github.com/sendinblue/APIv3-nodejs-library;
- [x] Test the script out by adding to listIds=[2] & In production, we need to add to listIds=[2] (done by env `SENDINBLUE_LIST_ID`, defaults to 2 if env is not found);

Footage of the functionality: https://www.youtube.com/watch?v=WsW2IWZtjJE