### PR TITLE
Minor styling fixes

### DIFF
--- a/packages/client/src/index.scss
+++ b/packages/client/src/index.scss
@@ -86,4 +86,11 @@ b {
 input, .mui-textfield > input {
   padding: 14px 6px;
   height: 22px;
+  padding-left: 0;
+}
+
+// Fixes scrollbars appearing on labels, issue only happens on Linux/Windows
+// on resolutions smaller than 1600x900
+.mui-textfield.mui-textfield--float-label > label {
+  overflow: hidden !important;
 }


### PR DESCRIPTION
Fixes input content being 6px after their labels and a small issue on linux/windows (scrollbars kept appearing on `label`).
* [Screenshot of the issue](https://user-images.githubusercontent.com/31702297/88229490-327cb780-cc47-11ea-849c-da16e9445ccb.png)
* [Screenshot of the fix](https://user-images.githubusercontent.com/31702297/88229491-33154e00-cc47-11ea-8b04-f453451c95ea.png)

