### PR TITLE
Shows the warning modal by default when visiting staging

### DIFF
--- a/packages/client/src/comp/WarningMsg.test.tsx
+++ b/packages/client/src/comp/WarningMsg.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { render, fireEvent, act } from '@testing-library/react'
+import { WarningMsg } from './WarningMsg'
+import { UnstatedContainer } from "./StateContainer"
+
+
+const renderResult = () => render(
+  <WarningMsg/>,
+  { wrapper: UnstatedContainer }
+)
+
+// When visiting the page for the first time
+
+test('Modal shows by default when visiting the page for the first time', () => {
+  localStorage.removeItem('visited')
+
+  const rendered = renderResult()
+
+  const modal = rendered.getByTestId('notProductionModal')
+
+  expect(modal).toBeInTheDocument()
+})
+test('Dismissing the modal triggers a toast when visiting the page for the first time', async () => {
+  localStorage.removeItem('visited')
+
+  const rendered = renderResult()
+
+  const dismissButton = rendered.getByTestId('notProductionButton')
+
+  await act(async () => {
+    await fireEvent.click(dismissButton)
+    // The modal has a small delay to hide due to its animations
+    await new Promise(r => setTimeout(() => r(), 800))
+  })
+
+  const toast = rendered.getByText('You can toggle this popup again by clicking on "Not Production" at the bottom right corner of the page.')
+
+  expect(toast).toBeInTheDocument()
+})
+
+// When visiting the page again
+
+test('Modal doesn\'t show by default when visiting the page again', () => {
+  localStorage.setItem('visited', 'true')
+
+  const rendered = renderResult()
+
+  const modal = rendered.queryByTestId('notProductionModal')
+
+  expect(modal).toBe(null)
+})
+
+test('Dismissing the modal doesn\'t trigger toasts when visiting the page again', async () => {
+  localStorage.setItem('visited', 'true')
+
+  const rendered = renderResult()
+
+  const dismissButton = rendered.getByTestId('notProductionButton')
+
+  await act(async () => {
+    await fireEvent.click(dismissButton)
+    // The modal has a small delay to hide due to its animations
+    await new Promise(r => setTimeout(() => r(), 800))
+  })
+
+  const toast = rendered.queryByText('You can toggle this popup again by clicking on "Not Production" at the bottom right corner of the page.')
+
+  expect(toast).toBe(null)
+})

--- a/packages/client/src/comp/WarningMsg.tsx
+++ b/packages/client/src/comp/WarningMsg.tsx
@@ -6,7 +6,7 @@ import { ImplementedState, isImplementedState } from '../common'
 import { useAppHistory, Path } from '../lib/path'
 import { InitialDataContainer } from '../lib/unstated'
 import { StateSelector, StateContainer } from './StateSelector'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { Button } from 'muicss/react'
 import { StyledModal } from './util/StyledModal'
 import { toast } from 'react-toastify'
@@ -118,6 +118,28 @@ const RawWarningMsg: React.FC<RawWarningProps> = ({ toggleOpen }) => {
   </ul>)
 }
 
+const openingAnimation = keyframes`
+  from {
+    transform: translate(100%, 100%);
+    opacity: 0;
+  }
+  to {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+`
+
+const dismissAnimation = keyframes`
+  from {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate(100%, 100%);
+    opacity: 0;
+  }
+`
+
 const ContainerlessWarningMsg = () => {
   const { initialData } = InitialDataContainer.useContainer()
   const { path } = useAppHistory()
@@ -137,6 +159,8 @@ const ContainerlessWarningMsg = () => {
       isOpen={open}
       onBackgroundClick={toggleOpen}
       onEscapeKeydown={toggleOpen}
+      openingAnimation={openingAnimation}
+      dismissAnimation={dismissAnimation}
     >
       <RedOutline>
         <h2>Warning: Not Production!</h2>

--- a/packages/client/src/comp/WarningMsg.tsx
+++ b/packages/client/src/comp/WarningMsg.tsx
@@ -148,7 +148,12 @@ const ContainerlessWarningMsg = () => {
   if (initialData?.emailFaxOfficials) return null
 
   return <>
-    <FloatingButton color="danger" onClick={toggleOpen} open={open}>
+    <FloatingButton
+      color="danger"
+      onClick={toggleOpen}
+      open={open}
+      data-testid='notProductionButton'
+    >
       {
         open
         ? <><i className="fa fa-close" aria-hidden="true"/> Close</>
@@ -161,6 +166,7 @@ const ContainerlessWarningMsg = () => {
       onEscapeKeydown={toggleOpen}
       openingAnimation={openingAnimation}
       dismissAnimation={dismissAnimation}
+      data-testid='notProductionModal'
     >
       <RedOutline>
         <h2>Warning: Not Production!</h2>

--- a/packages/client/src/comp/util/StyledModal.tsx
+++ b/packages/client/src/comp/util/StyledModal.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import Modal, { ModalProps } from 'styled-react-modal'
-import styled, { keyframes, css } from 'styled-components'
+import styled, { keyframes, css, Keyframes } from 'styled-components'
 
 const animationDurationMS = 350
 
 interface Props {
   hiding: boolean
+  openingAnimation?: Keyframes
+  dismissAnimation?: Keyframes
 }
 
-const entranceAnimation = keyframes`
+const openingAnimation = keyframes`
   from {
     transform: translateY(100%);
     opacity: 0;
@@ -19,7 +21,7 @@ const entranceAnimation = keyframes`
   }
 `
 
-const hidingAnimation = keyframes`
+const dismissAnimation = keyframes`
   from {
     transform: translateY(0);
     opacity: 1;
@@ -53,12 +55,12 @@ const RawStyledModal = styled(Modal.styled``)<Props>`
   }
 
   animation: ${p => p.hiding === false
-    ? css`${entranceAnimation}`
-    : css`${hidingAnimation}`
+    ? css`${p.openingAnimation ?? openingAnimation}`
+    : css`${p.dismissAnimation ?? dismissAnimation}`
   } ease ${animationDurationMS}ms both;
 `
 
-export const StyledModal: React.FC<ModalProps> = (props) => {
+export const StyledModal: React.FC<ModalProps & Omit<Props, 'hiding'>> = (props) => {
   const [hiding, setHiding] = React.useState(false)
 
   const beforeClose = () => new Promise(resolve => {


### PR DESCRIPTION
I could make the animation/toast more unique for this case but tried this first to ensure consistency with our overall design, but it's possible to make the modal collapse and move to the "Not Production" button if needed, then a tooltip would indicate it's possible to enable the modal again by clicking on the button.