### PR TITLE
Support for embedding website.

### DIFF
--- a/packages/client/src/comp/WarningMsg.tsx
+++ b/packages/client/src/comp/WarningMsg.tsx
@@ -12,7 +12,7 @@ import { StyledModal } from './util/StyledModal'
 import { toast } from 'react-toastify'
 import { createContainer } from 'unstated-next'
 import { AddressInputPartContainer } from './Address'
-import { isEmbedded } from '../lib/util'
+import { isIframeEmbedded } from '../lib/util'
 
 const defaultState = (path: Path | null): ImplementedState => {
   switch(path?.type) {
@@ -49,7 +49,7 @@ const useVisibility = () => {
   // To avoid this we wrap a state on the storage item to ensure this issue
   // doesn't happen.
   const [ visited, setVisited ] = React.useState(
-    isEmbedded() === false
+    !isIframeEmbedded()
       ? localStorage.getItem('visited') !== null
       : true
   )

--- a/packages/client/src/comp/WarningMsg.tsx
+++ b/packages/client/src/comp/WarningMsg.tsx
@@ -12,6 +12,7 @@ import { StyledModal } from './util/StyledModal'
 import { toast } from 'react-toastify'
 import { createContainer } from 'unstated-next'
 import { AddressInputPartContainer } from './Address'
+import { isEmbedded } from '../lib/util'
 
 const defaultState = (path: Path | null): ImplementedState => {
   switch(path?.type) {
@@ -47,7 +48,11 @@ const useVisibility = () => {
   //
   // To avoid this we wrap a state on the storage item to ensure this issue
   // doesn't happen.
-  const [ visited, setVisited ] = React.useState(localStorage.getItem('visited') !== null)
+  const [ visited, setVisited ] = React.useState(
+    isEmbedded() === false
+      ? localStorage.getItem('visited') !== null
+      : true
+  )
   const [ open, setOpen ] = React.useState(!visited)
   const toggleOpen = () => {
     if (!visited) {

--- a/packages/client/src/lib/path.ts
+++ b/packages/client/src/lib/path.ts
@@ -203,7 +203,7 @@ export const useAppHistory = () => {
     // Wrap it on window.onload since if we fire this before images are
     // completely served, users will be scrolled to the wrong area.
     const callback = () => {
-      const pattern = /#(start|about|howItWorks|getInvolved|team|contact)/
+      const pattern = /#(start|about|howItWorks|getInvolved|team|contact)$/
       const match = window.location.href.match(pattern)
       if (match && match?.length >= 0) {
         scrollToId(match[0].substring(1)) // removes '#'

--- a/packages/client/src/lib/path.ts
+++ b/packages/client/src/lib/path.ts
@@ -196,6 +196,23 @@ export const useAppHistory = () => {
     pageView()
   }, [history])
 
+  // Because we're using HashRouter, adding a #anchorID at the end of the
+  // url does not behave as expected, instead this effect below fires when
+  // the page
+  React.useEffect(() => {
+    // Wrap it on window.onload since if we fire this before images are
+    // completely served, users will be scrolled to the wrong area.
+    const callback = () => {
+      const pattern = /#(start|about|howItWorks|getInvolved|team|contact)/
+      const match = window.location.href.match(pattern)
+      if (match && match?.length >= 0) {
+        scrollToId(match[0].substring(1)) // removes '#'
+      }
+      window.removeEventListener('load', callback)
+    }
+    window.addEventListener('load', callback)
+  }, [])
+
   return {
     path,
     oid,

--- a/packages/client/src/lib/unstated/voter.ts
+++ b/packages/client/src/lib/unstated/voter.ts
@@ -2,13 +2,13 @@ import React from 'react'
 import { createContainer } from "unstated-next"
 import { Voter, UTM } from '../../common'
 import { useDeepMemoize } from './memoize'
-import { isEmbedded } from '../util'
+import { isIframeEmbedded } from '../util'
 
 const localStorageKey = 'voter-data'
 
 // https://medium.com/@jrcreencia/persisting-redux-state-to-local-storage-f81eb0b90e7e
 const loadLocalStorage = (): Partial<Voter> => {
-  if (isEmbedded()) return {}
+  if (isIframeEmbedded()) return {}
 
   const serialized = localStorage.getItem(localStorageKey)
   if (serialized === null) return {}
@@ -20,7 +20,7 @@ const loadLocalStorage = (): Partial<Voter> => {
 }
 
 const saveLocalStorage = (userData: Voter): void => {
-  if (isEmbedded()) { return }
+  if (isIframeEmbedded()) { return }
   const serialized = JSON.stringify(userData)
   localStorage.setItem(localStorageKey, serialized)
 }
@@ -44,7 +44,7 @@ const useVoterContainer = (initialState: Voter = defaultInitialState) => {
   /** Non-overwriting update of user data */
   const conservativeUpdateVoter = React.useCallback((utm: UTM) => {
     const newVoter = {...utm, ...voterMemo}
-    if (isEmbedded() === false) {
+    if (!isIframeEmbedded()) {
       saveLocalStorage(newVoter)
       setVoter(newVoter)
     }

--- a/packages/client/src/lib/util.ts
+++ b/packages/client/src/lib/util.ts
@@ -1,2 +1,2 @@
 /** Returns true if this instance of VoteByMail is inside an iframe */
-export const isEmbedded = () => window.location !== window.parent.location
+export const isIframeEmbedded = () => window.location !== window.parent.location

--- a/packages/client/src/lib/util.ts
+++ b/packages/client/src/lib/util.ts
@@ -1,0 +1,2 @@
+/** Returns true if this instance of VoteByMail is inside an iframe */
+export const isEmbedded = () => window.location !== window.parent.location

--- a/packages/server/src/service/org/passport.ts
+++ b/packages/server/src/service/org/passport.ts
@@ -165,7 +165,8 @@ export const registerPassportEndpoints = (app: Express.Application) => {
     const env = {
       REACT_APP_URL: process.env.REACT_APP_URL,
     }
-    res.render('embed', { env, richOrgs })
+    const states = [...implementedStates].sort()
+    res.render('embed', { env, richOrgs, states: ['No default state', ...states] })
   })
 
   app.get('/dashboard/:oid', validSession, orgPermissions('members'),

--- a/packages/server/src/service/org/passport.ts
+++ b/packages/server/src/service/org/passport.ts
@@ -157,16 +157,14 @@ export const registerPassportEndpoints = (app: Express.Application) => {
     }
   )
 
-  app.get('/dashboard/embed', validSession, async (req, res) => {
+  app.get('/embed/:oid', validSession, orgPermissions('members'), async (req, res) => {
     const uid = getUid(req)
-    const orgs = await firestoreService.fetchUserOrgs(uid)
-
-    const richOrgs = orgs.map(org => enrichOrg(org, uid))
     const env = {
       REACT_APP_URL: process.env.REACT_APP_URL,
     }
+    const richOrg = enrichOrg((req as RequestWithOrg).org, uid)
     const states = [...implementedStates].sort()
-    res.render('embed', { env, richOrgs, states: ['No default state', ...states] })
+    res.render('embed', { env, richOrg, states: ['No default state', ...states] })
   })
 
   app.get('/dashboard/:oid', validSession, orgPermissions('members'),

--- a/packages/server/src/service/org/passport.ts
+++ b/packages/server/src/service/org/passport.ts
@@ -157,6 +157,17 @@ export const registerPassportEndpoints = (app: Express.Application) => {
     }
   )
 
+  app.get('/dashboard/embed', validSession, async (req, res) => {
+    const uid = getUid(req)
+    const orgs = await firestoreService.fetchUserOrgs(uid)
+
+    const richOrgs = orgs.map(org => enrichOrg(org, uid))
+    const env = {
+      REACT_APP_URL: process.env.REACT_APP_URL,
+    }
+    res.render('embed', { env, richOrgs })
+  })
+
   app.get('/dashboard/:oid', validSession, orgPermissions('members'),
     async (req, res) => {
       const uid = getUid(req)
@@ -236,17 +247,6 @@ export const registerPassportEndpoints = (app: Express.Application) => {
       res.render('status', { env })
     }
   )
-
-  app.get('/embed', validSession, async (req, res) => {
-    const uid = getUid(req)
-    const orgs = await firestoreService.fetchUserOrgs(uid)
-
-    const richOrgs = orgs.map(org => enrichOrg(org, uid))
-    const env = {
-      REACT_APP_URL: process.env.REACT_APP_URL,
-    }
-    res.render('embed', { env, richOrgs })
-  })
 
   app.use('/letter', validSession, letterRouter)
 }

--- a/packages/server/src/service/org/passport.ts
+++ b/packages/server/src/service/org/passport.ts
@@ -237,5 +237,16 @@ export const registerPassportEndpoints = (app: Express.Application) => {
     }
   )
 
+  app.get('/embed', validSession, async (req, res) => {
+    const uid = getUid(req)
+    const orgs = await firestoreService.fetchUserOrgs(uid)
+
+    const richOrgs = orgs.map(org => enrichOrg(org, uid))
+    const env = {
+      REACT_APP_URL: process.env.REACT_APP_URL,
+    }
+    res.render('embed', { env, richOrgs })
+  })
+
   app.use('/letter', validSession, letterRouter)
 }

--- a/packages/server/src/service/static/pug/dashboard.pug
+++ b/packages/server/src/service/static/pug/dashboard.pug
@@ -31,8 +31,6 @@ block content
           ul
             li
               a(href='/letter/Florida-0') Sample Letter
-            li
-              a(href='/dashboard/embed') Instructions to Embed VoteByMail.io via iFrame
 
       .col-lg
         .card.mt-4.p-3

--- a/packages/server/src/service/static/pug/dashboard.pug
+++ b/packages/server/src/service/static/pug/dashboard.pug
@@ -27,17 +27,12 @@ block content
                 li.text-muted= email.value
 
         .card.mt-4.p-3
-          h3 Links
+          h3 Useful Links
           ul
             li
               a(href='/letter/Florida-0') Sample Letter
-
-        .card.mt-4.p-3
-          h3 VoteByMail Widget
-          p.text-muted Get to know how to add support for VoteByMail in your website.
-          ul
             li
-              a(href='/embed') See Examples
+              a(href='/embed') Instructions to Embed VoteByMail.io via iFrame
 
       .col-lg
         .card.mt-4.p-3

--- a/packages/server/src/service/static/pug/dashboard.pug
+++ b/packages/server/src/service/static/pug/dashboard.pug
@@ -32,7 +32,7 @@ block content
             li
               a(href='/letter/Florida-0') Sample Letter
             li
-              a(href='/embed') Instructions to Embed VoteByMail.io via iFrame
+              a(href='/dashboard/embed') Instructions to Embed VoteByMail.io via iFrame
 
       .col-lg
         .card.mt-4.p-3

--- a/packages/server/src/service/static/pug/dashboard.pug
+++ b/packages/server/src/service/static/pug/dashboard.pug
@@ -32,6 +32,13 @@ block content
             li
               a(href='/letter/Florida-0') Sample Letter
 
+        .card.mt-4.p-3
+          h3 VoteByMail Widget
+          p.text-muted Get to know how to add support for VoteByMail in your website.
+          ul
+            li
+              a(href='/embed') See Examples
+
       .col-lg
         .card.mt-4.p-3
           h3.text-primary Implemented States

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -75,6 +75,30 @@ block content
     const baseUrl = code.value;
     let state = '';
 
+    // When the iframe loads it might scroll to the address form, stealing
+    // window focus, we don't want that.
+    let lockScroll = false;
+    let lockScrollPosition = 0;
+
+    // Basically what we do is wait for a window scroll event, if it is
+    // different than lockScrollPosition we will consider that the iframe
+    // has finished loading, and with a short delay we'll unlock the page.
+    //
+    // We do this due to the safety measures blocking us from accessing
+    // iframe.onload from this page.
+    window.onscroll = function() {
+      if (window.scrollY !== lockScrollPosition) {
+        if (lockScroll) {
+          window.scroll({ top: lockScrollPosition });
+        }
+        // Adding a small timeout since it's a smooth animation
+        setTimeout(
+          function() { lockScroll = false },
+          500,
+        );
+      }
+    }
+
     function copyIframe() {
       // Select will only work if disabled is false
       code.disabled = false;
@@ -83,6 +107,8 @@ block content
       code.disabled = true;
     }
 
+    // scrollY must be a number, and if present it will lock scrolling the
+    // screen to the given position.
     function updateCode(scrollY) {
       // This is why our widget wasn't always updating, to see the changes
       // we must first clear the iframe.src and then (after a brief delay)
@@ -92,21 +118,10 @@ block content
         function() {
           iframe.src = `${baseUrl}${state}`;
           code.value = iframeWrapper.innerHTML;
-
-          // Prevents VoteByMail scroll events from stealing focus for half
-          // a second.
-          if (scrollY) {
-            for (let i = 0; i < 500; i++) {
-              setTimeout(
-                function() {
-                  window.scroll({
-                    top: scrollY,
-                  })
-                },
-                i,
-              );
-            }
-          }
+          // we'll lock scrolling if scrollY is provided (when users change
+          // default states).
+          lockScroll = scrollY !== undefined
+          lockScrollPosition = scrollY
         },
         50,
       );

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -18,7 +18,7 @@ block content
       .col.col-lg-6.col-sm-12
         .card.mt-4.p-3
           .card-body
-            h3 Anchor
+            h4.text-primary Anchor
             p Setting a HTML anchor will replace the default starting point of any web page, for example, in VoteByMail you can set an anchor to load the website from the "About Us" section.
             p.text-muted Setting a default state will replace this anchor, since the widget will start from the input address form.
             button(
@@ -55,10 +55,9 @@ block content
       .col.col-lg-6.col-sm-12
         .card.mt-4.p-3
           .card-body
-            h3 Widget configuration
-            p Use these to prefill the default state and organization of your embedded widget.
-            p.text-muted If you own or belong to an organization, they will be shown on the dropdown below for selection.
-            label(for='prefill-state') Prefill State
+            h4.text-primary Default state
+            p Use this field to prefill the default state of your embedded widget.
+            p.text-muted Setting an anchor will remove the effects of this field, since these settings are not compatible with each other.
             .input-group.mb-3
               select(
                 id='prefill-state'
@@ -72,26 +71,6 @@ block content
                     value=state
                   )= state
 
-            label(for='prefill-org') Prefill Organization
-            .input-group.mb-3
-              select(
-                id='prefill-org'
-                class='form-control'
-                aria-label='prefill org input'
-                onChange=`setOrg(this.value)`
-              )
-                //- Only add the default org option if the user doesn't own/belong to it.
-                if richOrgs.find(function(org) { return org.id === 'default' }) === undefined
-                  option(
-                    aria-label='default org'
-                    value='default'
-                  ) Default
-                each org in richOrgs
-                  option(
-                    aria-label=org.name ? `${org.name} (${org.id})` : org.id
-                    value=org.id
-                  )= org.name ? `${org.name} (${org.id})` : org.id
-
   .container.mt-4
     br
     h2 Widget code
@@ -103,7 +82,7 @@ block content
       style='display: block; width: 100%; padding: 10px; color: #dc0e52; background-color: #fafafa; margin: 25px 0; border-radius: 4px; resize: none;'
       resizable='false'
       disabled='true'
-    )= env.REACT_APP_URL
+    )=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
     button(class='btn btn-primary' onClick='copyIframe()') Copy
 
     br
@@ -112,13 +91,16 @@ block content
     div(style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;')
       iframe(
         id='vbm-iframe'
-        src=`${env.REACT_APP_URL}/${org}`
+        src=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
         style='width: 100%; height: 100%;'
       )
 
+    //- Creates an invisible input for acquiring the value of richOrg.id, since we
+    //- can't access this variable at the script tag below
+    input(value=richOrg.id style='display: none;' id='orgId')
+
 
   script.
-    let org = '';
     const iframe = document.getElementById('vbm-iframe');
     const code = document.getElementById('vbm-iframe-code');
     // The initial value of code is env.REACT_APP_URL (we can't access env here)
@@ -140,20 +122,17 @@ block content
       iframe.src = '';
       setTimeout(
         function() {
-          iframe.src = `${baseUrl}/${org}${anchor}${state}`;
+          iframe.src = `${baseUrl}${anchor}${state}`;
           code.value = iframe.outerHTML;
         },
         100,
       );
     }
 
-    function setOrg(oid) {
-      org = `#/org/${oid ? oid : 'default'}`;
-      updateCode();
-    }
-
     function setAnchor(a) {
       anchor = a;
+      state = '';
+      document.getElementById('prefill-state').value = 'No default state'
       updateCode();
     }
 
@@ -163,5 +142,5 @@ block content
       updateCode();
     }
 
-    // Initialize default values
-    setOrg(org);
+    // Initializes default values
+    updateCode();

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -3,6 +3,11 @@ extends layout.pug
 block pageName
   title Embedding VoteByMail.io
   meta(name="viewport", content="width=device-width, initial-scale=1.0")
+  style.
+    div > button {
+      margin-right: 15px;
+      margin-bottom: 15px;
+    }
 
 block content
   .container.mt-4
@@ -25,13 +30,11 @@ block content
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('340px', '620px')"
-              style='margin-right: 15px; margin-bottom: 15px;'
             ) Small (340x620)
             button(
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('768px', '1024px')"
-              style=''
             ) Big (768x1024)
 
       .col.col-lg-6.col-sm-12
@@ -44,13 +47,11 @@ block content
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('1024px', '768px')"
-              style='margin-right: 15px; margin-bottom: 15px;'
             ) Small (1024x768)
             button(
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('1366px', '768px')"
-              style=''
             ) Big (1366x768)
 
       .col.col-lg-6.col-sm-12
@@ -64,7 +65,6 @@ block content
                 onClick=`setOrg('${org.id}', true)`
                 aria-label=org.name ? `${org.name} (${org.id})` : org.id
                 class='btn btn-primary'
-                style='margin-right: 15px; margin-bottom: 15px;'
               )= org.name ? `${org.name} (${org.id})` : org.id
 
             .input-group.mb-3

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -12,20 +12,20 @@ block pageName
 block content
   .container.mt-4
     h1 Embedding VoteByMail.io
-    p This page helps you to embed VoteByMail.io to your website, in order for these steps to be successful you must at least have the power to edit HTML content of the pages you're wishing to edit. Also, due to the safety measures adopted by modern browsers, these methods are only guaranteed to work on secure web pages, i.e. websites using SSL/HTTPS connections.
+    p This page guides you on creating embeddable versions of VoteByMail.io, in order for these steps to be successful you must at least have the power to edit HTML content from the pages you're wishing to edit, hence if using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Due to the safety measures adopted by modern browsers, these methods are only guaranteed to work on secure web pages, i.e. websites using SSL/HTTPS connections.
 
     br
     h2 Selecting the right widget
-    p There are multiple versions of the VoteByMail widget to add to your website, this helps fitting our application on your page as well as helping voters sign up more efficiently.
-    p Please note that all widgets offer the same functionality, and their only difference is aesthetics.
+    p We make available multiple versions of the VoteByMail Widget to add to your website, this helps better fitting our application in your page, as well as helping voters sign up more efficiently.
+    p Please note that all widgets offer the same functionality, but having only aesthetical differences among them.
 
     .row
       .col.col-lg-6.col-sm-12
         .card.mt-4.p-3
           .card-body
             h3 Portrait widgets
-            p These are ideal for mobile devices or when you need to fit the VoteByMail Widget in a constrained space.
-            p.text-muted Small (340x620) is the only one that fits all smartphones and devices.
+            p These are ideal for mobile devices or when you need to fit VoteByMail Widget in a constrained space.
+            p.text-muted Small (340x620) will display correctly on all smartphones and desktop devices.
             button(
               type='button'
               class='btn btn-primary'
@@ -41,7 +41,7 @@ block content
         .card.mt-4.p-3
           .card-body
             h3 Landscape widgets
-            p These are ideal for wider devices such as computers and tablets, as well as webpages with lots of space available.
+            p These are ideal for wider devices such as computers and tablets, but essentially great for webpages with lots of space available.
             p.text-muted We suggest you to use the Flexible Widget below if you need even bigger dimensions.
             button(
               type='button'
@@ -58,15 +58,14 @@ block content
         .card.mt-4.p-3
           .card-body
             h3 Organization changes
-            p You can fill the input below to replace the default organization, or (recommended) click in one of the buttons to update the Widget Code for your desired organization.
-            p.text-muted Only type in the field if you want to manually generate a Widget for an unlisted organization.
+            p You can fill the input below to replace the default organization used by our website. If you plan to replace the default organization with one of yours, we recommend you to select them by clicking on its respective button.
+            p.text-muted Only manually type in the field below to generate a Widget for an unlisted organization.
             each org in richOrgs
               button(
                 onClick=`setOrg('${org.id}', true)`
                 aria-label=org.name ? `${org.name} (${org.id})` : org.id
                 class='btn btn-primary'
               )= org.name ? `${org.name} (${org.id})` : org.id
-
             .input-group.mb-3
               input(
                 id='vbm-iframe-org-input'
@@ -88,8 +87,8 @@ block content
         .card.mt-4.p-3
           .card-body
             h3 Flexible Widget
-            p This embedded version of VoteByMail will fill the entire space available by its parent container, this feature allows this widget to responsively adapt to both mobile and desktop devices, although this might require some CSS adjustments to be fully functional.
-            p.text-muted Remember to set both the #[code height] and #[code width] of the parent container, otherwise the widget won't expand at all.
+            p This embedded version of VoteByMail will fill the entire space available by its parent container, this feature allows this widget to responsively adapt to both mobile and desktop devices, although some CSS knowledge will be required in order to implement this functionality.
+            p.text-muted Remember to set both #[code height] and #[code width] of the parent container, otherwise the widget won't expand at all.
             button(
               type='button'
               class='btn btn-primary'
@@ -107,7 +106,7 @@ block content
 
     br
     h3 Preview
-    p.text-muted The dashed red border indicates the available space for the widget, except for #[b Flexible Widget] this area might be overlapped by the other options.
+    p.text-muted The dashed red border indicates the available space for the widget, except for #[b Flexible Widget] this area might be overlapped by other options.
     div(style='height: 1024px; width: 100%; border: 2px dashed #dc0e52;')
       iframe(
         id='vbm-iframe'

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -18,40 +18,9 @@ block content
       .col.col-lg-6.col-sm-12
         .card.mt-4.p-3
           .card-body
-            h3 Organization changes
-            p You can fill the input below to replace the default organization used by our website. If you plan to replace the default organization with one of yours, we recommend you to select them by clicking on its respective button.
-            p.text-muted Only manually type in the field below to generate a Widget for an unlisted organization.
-            each org in richOrgs
-              button(
-                onClick=`setOrg('${org.id}', true)`
-                aria-label=org.name ? `${org.name} (${org.id})` : org.id
-                class='btn btn-primary'
-              )= org.name ? `${org.name} (${org.id})` : org.id
-            .input-group.mb-3
-              input(
-                id='vbm-iframe-org-input'
-                class='form-control'
-                placeholder='Custom org id, e.g. vbm_org'
-                onChange='setOrg(this.value)'
-                aria-label='custom org input'
-              )
-              .input-group-append
-                // This button actually does nothing, but vanilla js
-                // onChange might trigger only after the input is blurred
-                // on some browsers, unlike the default behavior in React
-                button(
-                  class='btn btn-primary'
-                  aria-label='save changes'
-                ) Save
-
-      .col.col-lg-6.col-sm-12
-        .card.mt-4.p-3
-          .card-body
             h3 Anchor
-            p Setting a HTML anchor will replace the default starting point of any web page, for example, in VoteByMail you can set the page to start showing the "About Us" section instead from the top.
-            //- The dashes below are em dashes, although most monospace fonts are
-            //- going to render them equally as a dash
-            p It's possible to set this to any of the sections of our landing page, or—if you want to speed up the sign up process—fill the default value of the zip code.
+            p Setting a HTML anchor will replace the default starting point of any web page, for example, in VoteByMail you can set an anchor to load the website from the "About Us" section.
+            p.text-muted Setting a default state will replace this anchor, since the widget will start from the input address form.
             button(
               type='button'
               class='btn btn-primary'
@@ -82,34 +51,60 @@ block content
               class='btn btn-primary'
               onClick="setAnchor('#about')"
             ) About Us
-            br
-            label(for='prefill-zip') Prefill Zip Code
-            div(class='input-group mb-3' style='max-width:370px')
-              input(
-                id='prefill-zip'
+
+      .col.col-lg-6.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Widget configuration
+            p Use these to prefill the default state and organization of your embedded widget.
+            p.text-muted If you own or belong to an organization, they will be shown on the dropdown below for selection.
+            label(for='prefill-state') Prefill State
+            .input-group.mb-3
+              select(
+                id='prefill-state'
                 class='form-control'
-                placeholder='Prefill zip code, e.g. 33131'
-                onChange='setZip(this.value)'
-                aria-label='custom org input'
-                pattern='[0-9]{5}'
-                type='number'
+                aria-label='prefill state input'
+                onChange=`setState(this.value)`
               )
-              .input-group-append
-                // This button actually does nothing, but vanilla js
-                // onChange might trigger only after the input is blurred
-                // on some browsers, unlike the default behavior in React
-                button(
-                  class='btn btn-primary'
-                  aria-label='save changes'
-                ) Save
+                each state in states
+                  option(
+                    aria-label=state
+                    value=state
+                  )= state
+
+            label(for='prefill-org') Prefill Organization
+            .input-group.mb-3
+              select(
+                id='prefill-org'
+                class='form-control'
+                aria-label='prefill org input'
+                onChange=`setOrg(this.value)`
+              )
+                //- Only add the default org option if the user doesn't own/belong to it.
+                if richOrgs.find(function(org) { return org.id === 'default' }) === undefined
+                  option(
+                    aria-label='default org'
+                    value='default'
+                  ) Default
+                each org in richOrgs
+                  option(
+                    aria-label=org.name ? `${org.name} (${org.id})` : org.id
+                    value=org.id
+                  )= org.name ? `${org.name} (${org.id})` : org.id
 
   .container.mt-4
     br
     h2 Widget code
     br
-    div.alert.alert-secondary(style='background-color: #fbfbfb;')
-      p Please copy the text in red and add it to your website, the code in this block updates automatically as you edit your widget.
-      code(id='vbm-iframe-code')= env.REACT_APP_URL
+    p Please copy the text in red and add it to your website, the code in this block updates automatically as you edit your widget.
+    textarea(
+      name='vbm-iframe-code'
+      id='vbm-iframe-code'
+      style='display: block; width: 100%; padding: 10px; color: #dc0e52; background-color: #fafafa; margin: 25px 0; border-radius: 4px; resize: none;'
+      resizable='false'
+      disabled='true'
+    )= env.REACT_APP_URL
+    button(class='btn btn-primary' onClick='copyIframe()') Copy
 
     br
     h3 Preview
@@ -127,21 +122,34 @@ block content
     const iframe = document.getElementById('vbm-iframe');
     const code = document.getElementById('vbm-iframe-code');
     // The initial value of code is env.REACT_APP_URL (we can't access env here)
-    const baseUrl = code.innerText;
+    const baseUrl = code.value;
     let anchor = '';
-    let zip = '';
+    let state = '';
 
-    function updateCode() {
-      iframe.src = `${baseUrl}/${org}${anchor}${zip}`;
-      code.innerText = iframe.outerHTML;
+    function copyIframe() {
+      // Select will only work if disabled is false
+      code.disabled = false;
+      code.select();
+      document.execCommand('copy');
+      code.disabled = true;
     }
 
-    function setOrg(oid, clearInput) {
+    function updateCode() {
+      // This is why our widget wasn't always updating, to see the changes we must first
+      // clear the iframe.src and then (after a brief delay) load our url.
+      iframe.src = '';
+      setTimeout(
+        function() {
+          iframe.src = `${baseUrl}/${org}${anchor}${state}`;
+          code.value = iframe.outerHTML;
+        },
+        100,
+      );
+    }
+
+    function setOrg(oid) {
       org = `#/org/${oid ? oid : 'default'}`;
       updateCode();
-      if (clearInput) {
-        document.getElementById('vbm-iframe-org-input').value = '';
-      }
     }
 
     function setAnchor(a) {
@@ -149,8 +157,9 @@ block content
       updateCode();
     }
 
-    function setZip(z) {
-      zip = z ? `?postcode=${z}` : ''
+    function setState(s) {
+      anchor = '';
+      state = s !== 'No default state' ? `/address/${s}` : '';
       updateCode();
     }
 

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -15,49 +15,11 @@ block content
     p This page guides you on creating embeddable versions of VoteByMail.io.  In order for these steps to be successful, you must be able to insert the iFrame into your page.  If using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Also, due to the safety measures adopted by modern browsers, your page must be HTTPS (not HTTP) for this to work.
 
     .row
-      .col.col-lg-6.col-sm-12
-        .card.mt-4.p-3
-          .card-body
-            h4.text-primary Anchor
-            p Setting a HTML anchor will replace the default starting point of any web page, for example, in VoteByMail you can set an anchor to load the website from the "About Us" section.
-            p.text-muted Setting a default state will replace this anchor, since the widget will start from the input address form.
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('')"
-            ) Default (top)
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('#howItWorks')"
-            ) How does it work?
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('#getInvolved')"
-            ) Get Involved
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('#team')"
-            ) Team
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('#contact')"
-            ) Contact Us
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setAnchor('#about')"
-            ) About Us
-
-      .col.col-lg-6.col-sm-12
+      .col.col-lg
         .card.mt-4.p-3
           .card-body
             h4.text-primary Default state
             p Use this field to prefill the default state of your embedded widget.
-            p.text-muted Setting an anchor will remove the effects of this field, since these settings are not compatible with each other.
             .input-group.mb-3
               select(
                 id='prefill-state'
@@ -105,7 +67,6 @@ block content
     const code = document.getElementById('vbm-iframe-code');
     // The initial value of code is env.REACT_APP_URL (we can't access env here)
     const baseUrl = code.value;
-    let anchor = '';
     let state = '';
 
     function copyIframe() {
@@ -122,18 +83,11 @@ block content
       iframe.src = '';
       setTimeout(
         function() {
-          iframe.src = `${baseUrl}${anchor}${state}`;
+          iframe.src = `${baseUrl}${state}`;
           code.value = iframe.outerHTML;
         },
         100,
       );
-    }
-
-    function setAnchor(a) {
-      anchor = a;
-      state = '';
-      document.getElementById('prefill-state').value = 'No default state'
-      updateCode();
     }
 
     function setState(s) {

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -14,42 +14,38 @@ block content
     h1 Embedding VoteByMail.io
     p This page guides you on creating embeddable versions of VoteByMail.io.  In order for these steps to be successful, you must be able to insert the iFrame into your page.  If using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Also, due to the safety measures adopted by modern browsers, your page must be HTTPS (not HTTP) for this to work.
 
-    .row
-      .col.col-lg
-        .card.mt-4.p-3
-          .card-body
-            h4.text-primary Default state
-            p Use this field to prefill the default state of your embedded widget.
-            .input-group.mb-3
-              select(
-                id='prefill-state'
-                class='form-control'
-                aria-label='prefill state input'
-                onChange=`setState(this.value)`
-              )
-                each state in states
-                  option(
-                    aria-label=state
-                    value=state
-                  )= state
+    .card
+      .card-body.row
+        .col.col-md-6.col-sm-12.mt-3
+          h4.text-primary Default State
+          p Select default state (or no default)
+          .input-group.mb-3
+            select(
+              id='prefill-state'
+              class='form-control'
+              aria-label='prefill state input'
+              onChange=`setState(this.value)`
+            )
+              each state in states
+                option(
+                  aria-label=state
+                  value=state
+                )= state
 
-  .container.mt-4
-    br
-    h2 Widget code
-    br
-    p Please copy the text in red and add it to your website, the code in this block updates automatically as you edit your widget.
-    textarea(
-      name='vbm-iframe-code'
-      id='vbm-iframe-code'
-      style='display: block; width: 100%; padding: 10px; color: #dc0e52; background-color: #fafafa; margin: 25px 0; border-radius: 4px; resize: none;'
-      resizable='false'
-      disabled='true'
-    )=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
-    button(class='btn btn-primary' onClick='copyIframe()') Copy
+        .col.col-md-6.col-sm-12.mt-3
+          h4.text-primary Widget Code
+          textarea(
+            name='vbm-iframe-code'
+            id='vbm-iframe-code'
+            style='display: block; width: 100%; padding: 10px; color: #dc0e52; background-color: #fafafa; margin: 25px 0; border-radius: 4px; resize: none;'
+            resizable='false'
+            disabled='true'
+          )=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
+          button(class='btn btn-primary' onClick='copyIframe()') Copy
 
     br
     h3 Preview
-    p.text-muted The dashed red border indicates the available space for the widget.
+    p.text-muted The dashed red border does not appear in your embed.
     div(
       id='vbm-iframe-wrapper'
       style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;'

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -2,6 +2,7 @@ extends layout.pug
 
 block pageName
   title Embedding VoteByMail.io
+  meta(name="viewport", content="width=device-width, initial-scale=1.0")
 
 block content
   .container.mt-4
@@ -23,13 +24,13 @@ block content
             button(
               type='button'
               class='btn btn-primary'
-              onClick='setDimensions(340, 620)'
-              style='margin-right: 15px;'
+              onClick="setDimensions('340px', '620px')"
+              style='margin-right: 15px; margin-bottom: 15px;'
             ) Small (340x620)
             button(
               type='button'
               class='btn btn-primary'
-              onClick='setDimensions(768, 1024)'
+              onClick="setDimensions('768px', '1024px')"
               style=''
             ) Big (768x1024)
 
@@ -42,13 +43,13 @@ block content
             button(
               type='button'
               class='btn btn-primary'
-              onClick='setDimensions(1024, 768)'
-              style='margin-right: 15px;'
+              onClick="setDimensions('1024px', '768px')"
+              style='margin-right: 15px; margin-bottom: 15px;'
             ) Small (1024x768)
             button(
               type='button'
               class='btn btn-primary'
-              onClick='setDimensions(1366, 768)'
+              onClick="setDimensions('1366px', '768px')"
               style=''
             ) Big (1366x768)
 
@@ -83,6 +84,18 @@ block content
                   aria-label='save changes'
                 ) Save
 
+      .col.col-lg-6.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Flexible Widget
+            p This embedded version of VoteByMail will fill the entire space available by its parent container, this feature allows this widget to responsively adapt to both mobile and desktop devices, although this might require some CSS adjustments to be fully functional.
+            p.text-muted Remember to set both the #[code height] and #[code width] of the parent container, otherwise the widget won't expand at all.
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setDimensions('100%', '100%')"
+            ) Flexible Dimensions
+
   .container.mt-4
     br
     h2 Widget code
@@ -92,16 +105,19 @@ block content
       code(id='vbm-iframe-code')= env.REACT_APP_URL
 
 
+    br
     h3 Preview
-    iframe(
-      id='vbm-iframe'
-      src=`${env.REACT_APP_URL}/${org}`
-    )
+    p.text-muted The dashed red border indicates the available space for the widget, except for #[b Flexible Widget] this area might be overlapped by the other options.
+    div(style='height: 1024px; width: 100%; border: 2px dashed #dc0e52;')
+      iframe(
+        id='vbm-iframe'
+        src=`${env.REACT_APP_URL}/${org}`
+      )
 
 
   script.
-    let width = 340;
-    let height = 620;
+    let width = '340px';
+    let height = '620px';
     let org = '';
     const iframe = document.getElementById('vbm-iframe');
     const code = document.getElementById('vbm-iframe-code');
@@ -111,8 +127,8 @@ block content
     function setDimensions(w, h) {
       width = w;
       height = h;
-      iframe.style.width = `${width}px`;
-      iframe.style.height = `${height}px`;
+      iframe.style.width = w;
+      iframe.style.height = h;
       code.innerText = iframe.outerHTML;
     }
 

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -14,50 +14,7 @@ block content
     h1 Embedding VoteByMail.io
     p This page guides you on creating embeddable versions of VoteByMail.io.  In order for these steps to be successful, you must be able to insert the iFrame into your page.  If using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Also, due to the safety measures adopted by modern browsers, your page must be HTTPS (not HTTP) for this to work.
 
-    br
-    h2 Selecting the right widget
-    p We make available multiple versions of the VoteByMail Widget to add to your website, this helps better fitting our application in your page, as well as helping voters sign up more efficiently.
-    p Please note that all widgets offer the same functionality, having only aesthetical differences among them.
-
     .row
-      .col.col-lg-6.col-sm-12
-        .card.mt-4.p-3
-          .card-body
-            h3 Portrait widgets
-            p These are ideal for mobile devices or when you need to fit VoteByMail Widget in a constrained space.
-            p.text-muted Small (340x620) will display correctly on all smartphones and desktop devices.
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setDimensions('340px', '620px')"
-              aria-label='set dimensions to 340px wide and 620px tall'
-            ) Small (340x620)
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setDimensions('768px', '1024px')"
-              aria-label='set dimensions to 768px wide and 1024px tall'
-            ) Big (768x1024)
-
-      .col.col-lg-6.col-sm-12
-        .card.mt-4.p-3
-          .card-body
-            h3 Landscape widgets
-            p These are ideal for wider devices such as computers and tablets, but essentially great for webpages with lots of space available.
-            p.text-muted We suggest you to use the Flexible Widget below if you need even bigger dimensions.
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setDimensions('1024px', '768px')"
-              aria-label='set dimensions to 1024px wide and 768px tall'
-            ) Small (1024x768)
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setDimensions('1366px', '768px')"
-              aria-label='set dimensions to 1366px wide and 768px tall'
-            ) Big (1366x768)
-
       .col.col-lg-6.col-sm-12
         .card.mt-4.p-3
           .card-body
@@ -88,19 +45,6 @@ block content
                 ) Save
 
       .col.col-lg-6.col-sm-12
-        .card.mt-4.p-3
-          .card-body
-            h3 Flexible Widget
-            p This embedded version of VoteByMail will fill the entire space available by its parent container, this feature allows this widget to responsively adapt to both mobile and desktop devices, although some CSS knowledge will be required in order to implement this functionality.
-            p.text-muted Remember to set both #[code height] and #[code width] of the parent container, otherwise the widget won't expand at all.
-            button(
-              type='button'
-              class='btn btn-primary'
-              onClick="setDimensions('100%', '100%')"
-              aria-label='enable flexible dimensions'
-            ) Flexible Dimensions
-
-      .col.col-lg-12.col-sm-12
         .card.mt-4.p-3
           .card-body
             h3 Anchor
@@ -169,17 +113,16 @@ block content
 
     br
     h3 Preview
-    p.text-muted The dashed red border indicates the available space for the widget, except for #[b Flexible Widget] this area might be overlapped by other options.
-    div(style='height: 1024px; width: 100%; border: 2px dashed #dc0e52;')
+    p.text-muted The dashed red border indicates the available space for the widget.
+    div(style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;')
       iframe(
         id='vbm-iframe'
         src=`${env.REACT_APP_URL}/${org}`
+        style='width: 100%; height: 100%;'
       )
 
 
   script.
-    let width = '340px';
-    let height = '620px';
     let org = '';
     const iframe = document.getElementById('vbm-iframe');
     const code = document.getElementById('vbm-iframe-code');
@@ -191,14 +134,6 @@ block content
     function updateCode() {
       iframe.src = `${baseUrl}/${org}${anchor}${zip}`;
       code.innerText = iframe.outerHTML;
-    }
-
-    function setDimensions(w, h) {
-      width = w;
-      height = h;
-      iframe.style.width = w;
-      iframe.style.height = h;
-      updateCode();
     }
 
     function setOrg(oid, clearInput) {
@@ -220,5 +155,4 @@ block content
     }
 
     // Initialize default values
-    setDimensions(width, height);
     setOrg(org);

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -12,7 +12,7 @@ block pageName
 block content
   .container.mt-4
     h1 Embedding VoteByMail.io
-    p This page guides you on creating embeddable versions of VoteByMail.io, in order for these steps to be successful you must at least have the power to edit HTML content from the pages you're wishing to edit, hence if using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Due to the safety measures adopted by modern browsers, these methods are only guaranteed to work on secure web pages, i.e. websites using SSL/HTTPS connections.
+    p This page guides you on creating embeddable versions of VoteByMail.io.  In order for these steps to be successful, you must be able to insert the iFrame into your page.  If using a Content Management System, like WordPress or Drupal, double-check that you're actually editing the raw content of the page and not using any WYSIWYG editor provided by these tools. Also, due to the safety measures adopted by modern browsers, your page must be HTTPS (not HTTP) for this to work.
 
     br
     h2 Selecting the right widget

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -50,22 +50,32 @@ block content
     br
     h3 Preview
     p.text-muted The dashed red border indicates the available space for the widget.
-    div(style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;')
+    div(
+      id='vbm-iframe-wrapper'
+      style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;'
+    )
       iframe(
         id='vbm-iframe'
         src=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
-        style='width: 100%; height: 100%;'
+        width='100%'
+        height='100%'
+        marginheight='0'
+        frameborder='0'
       )
-
-    //- Creates an invisible input for acquiring the value of richOrg.id, since we
-    //- can't access this variable at the script tag below
-    input(value=richOrg.id style='display: none;' id='orgId')
+      script(
+        type='text/javascript'
+        src='//cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.3/iframeResizer.min.js'
+      )
+      //- More information about iFrameResize at
+      //- http://davidjbradshaw.github.io/iframe-resizer/
+      script iFrameResize({checkOrigin: false,scrolling: true,minHeight: 640,minWidth: 340,id: 'vbm-iframe'});
 
 
   script.
+    const iframeWrapper = document.getElementById('vbm-iframe-wrapper');
     const iframe = document.getElementById('vbm-iframe');
     const code = document.getElementById('vbm-iframe-code');
-    // The initial value of code is env.REACT_APP_URL (we can't access env here)
+    // The initial value of code is env.REACT_APP_URL + orgId (we can't access these here)
     const baseUrl = code.value;
     let state = '';
 
@@ -84,7 +94,7 @@ block content
       setTimeout(
         function() {
           iframe.src = `${baseUrl}${state}`;
-          code.value = iframe.outerHTML;
+          code.value = iframeWrapper.innerHTML;
         },
         100,
       );

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -1,0 +1,130 @@
+extends layout.pug
+
+block pageName
+  title Embedding VoteByMail.io
+
+block content
+  .container.mt-4
+    h1 Embedding VoteByMail.io
+    p This page helps you to embed VoteByMail.io to your website, in order for these steps to be successful you must at least have the power to edit HTML content of the pages you're wishing to edit. Also, due to the safety measures adopted by modern browsers, these methods are only guaranteed to work on secure web pages, i.e. websites using SSL/HTTPS connections.
+
+    br
+    h2 Selecting the right widget
+    p There are multiple versions of the VoteByMail widget to add to your website, this helps fitting our application on your page as well as helping voters sign up more efficiently.
+    p Please note that all widgets offer the same functionality, and their only difference is aesthetics.
+
+    .row
+      .col.col-lg-6.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Portrait widgets
+            p These are ideal for mobile devices or when you need to fit the VoteByMail Widget in a constrained space.
+            p.text-muted Small (340x620) is the only one that fits all smartphones and devices.
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick='setDimensions(340, 620)'
+              style='margin-right: 15px;'
+            ) Small (340x620)
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick='setDimensions(768, 1024)'
+              style=''
+            ) Big (768x1024)
+
+      .col.col-lg-6.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Landscape widgets
+            p These are ideal for wider devices such as computers and tablets, as well as webpages with lots of space available.
+            p.text-muted We suggest you to use the Flexible Widget below if you need even bigger dimensions.
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick='setDimensions(1024, 768)'
+              style='margin-right: 15px;'
+            ) Small (1024x768)
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick='setDimensions(1366, 768)'
+              style=''
+            ) Big (1366x768)
+
+      .col.col-lg-6.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Organization changes
+            p You can fill the input below to replace the default organization, or (recommended) click in one of the buttons to update the Widget Code for your desired organization.
+            p.text-muted Only type in the field if you want to manually generate a Widget for an unlisted organization.
+            each org in richOrgs
+              button(
+                onClick=`setOrg('${org.id}', true)`
+                aria-label=org.name ? `${org.name} (${org.id})` : org.id
+                class='btn btn-primary'
+                style='margin-right: 15px; margin-bottom: 15px;'
+              )= org.name ? `${org.name} (${org.id})` : org.id
+
+            .input-group.mb-3
+              input(
+                id='vbm-iframe-org-input'
+                class='form-control'
+                placeholder='Custom org id, e.g. vbm_org'
+                onChange='setOrg(this.value)'
+                aria-label='custom org input'
+              )
+              .input-group-append
+                // This button actually does nothing, but vanilla js
+                // onChange might trigger only after the input is blurred
+                // on some browsers, unlike the default behavior in React
+                button(
+                  class='btn btn-primary'
+                  aria-label='save changes'
+                ) Save
+
+  .container.mt-4
+    br
+    h2 Widget code
+    br
+    div.alert.alert-secondary(style='background-color: #fbfbfb;')
+      p Please copy the text in red and add it to your website, the code in this block updates automatically as you edit your widget.
+      code(id='vbm-iframe-code')= env.REACT_APP_URL
+
+
+    h3 Preview
+    iframe(
+      id='vbm-iframe'
+      src=`${env.REACT_APP_URL}/${org}`
+    )
+
+
+  script.
+    let width = 340;
+    let height = 620;
+    let org = '';
+    const iframe = document.getElementById('vbm-iframe');
+    const code = document.getElementById('vbm-iframe-code');
+    // The initial value of code is env.REACT_APP_URL (we can't access env here)
+    const baseUrl = code.innerText;
+
+    function setDimensions(w, h) {
+      width = w;
+      height = h;
+      iframe.style.width = `${width}px`;
+      iframe.style.height = `${height}px`;
+      code.innerText = iframe.outerHTML;
+    }
+
+    function setOrg(oid, clearInput) {
+      org = `#/org/${oid ? oid : 'default'}`;
+      iframe.src = `${baseUrl}/${org}`;
+      code.innerText = iframe.outerHTML;
+      if (clearInput) {
+        document.getElementById('vbm-iframe-org-input').value = ''
+      }
+    }
+
+    // Initialize default values
+    setDimensions(width, height)
+    setOrg(org)

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -83,23 +83,39 @@ block content
       code.disabled = true;
     }
 
-    function updateCode() {
-      // This is why our widget wasn't always updating, to see the changes we must first
-      // clear the iframe.src and then (after a brief delay) load our url.
+    function updateCode(scrollY) {
+      // This is why our widget wasn't always updating, to see the changes
+      // we must first clear the iframe.src and then (after a brief delay)
+      // load our url.
       iframe.src = '';
       setTimeout(
         function() {
           iframe.src = `${baseUrl}${state}`;
           code.value = iframeWrapper.innerHTML;
+
+          // Prevents VoteByMail scroll events from stealing focus for half
+          // a second.
+          if (scrollY) {
+            for (let i = 0; i < 500; i++) {
+              setTimeout(
+                function() {
+                  window.scroll({
+                    top: scrollY,
+                  })
+                },
+                i,
+              );
+            }
+          }
         },
-        100,
+        50,
       );
     }
 
     function setState(s) {
       anchor = '';
       state = s !== 'No default state' ? `/address/${s}` : '';
-      updateCode();
+      updateCode(window.scrollY);
     }
 
     // Initializes default values

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -17,7 +17,7 @@ block content
     br
     h2 Selecting the right widget
     p We make available multiple versions of the VoteByMail Widget to add to your website, this helps better fitting our application in your page, as well as helping voters sign up more efficiently.
-    p Please note that all widgets offer the same functionality, but having only aesthetical differences among them.
+    p Please note that all widgets offer the same functionality, having only aesthetical differences among them.
 
     .row
       .col.col-lg-6.col-sm-12
@@ -30,11 +30,13 @@ block content
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('340px', '620px')"
+              aria-label='set dimensions to 340px wide and 620px tall'
             ) Small (340x620)
             button(
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('768px', '1024px')"
+              aria-label='set dimensions to 768px wide and 1024px tall'
             ) Big (768x1024)
 
       .col.col-lg-6.col-sm-12
@@ -47,11 +49,13 @@ block content
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('1024px', '768px')"
+              aria-label='set dimensions to 1024px wide and 768px tall'
             ) Small (1024x768)
             button(
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('1366px', '768px')"
+              aria-label='set dimensions to 1366px wide and 768px tall'
             ) Big (1366x768)
 
       .col.col-lg-6.col-sm-12
@@ -93,7 +97,67 @@ block content
               type='button'
               class='btn btn-primary'
               onClick="setDimensions('100%', '100%')"
+              aria-label='enable flexible dimensions'
             ) Flexible Dimensions
+
+      .col.col-lg-12.col-sm-12
+        .card.mt-4.p-3
+          .card-body
+            h3 Anchor
+            p Setting a HTML anchor will replace the default starting point of any web page, for example, in VoteByMail you can set the page to start showing the "About Us" section instead from the top.
+            //- The dashes below are em dashes, although most monospace fonts are
+            //- going to render them equally as a dash
+            p It's possible to set this to any of the sections of our landing page, or—if you want to speed up the sign up process—fill the default value of the zip code.
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('')"
+            ) Default (top)
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('#howItWorks')"
+            ) How does it work?
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('#getInvolved')"
+            ) Get Involved
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('#team')"
+            ) Team
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('#contact')"
+            ) Contact Us
+            button(
+              type='button'
+              class='btn btn-primary'
+              onClick="setAnchor('#about')"
+            ) About Us
+            br
+            label(for='prefill-zip') Prefill Zip Code
+            div(class='input-group mb-3' style='max-width:370px')
+              input(
+                id='prefill-zip'
+                class='form-control'
+                placeholder='Prefill zip code, e.g. 33131'
+                onChange='setZip(this.value)'
+                aria-label='custom org input'
+                pattern='[0-9]{5}'
+                type='number'
+              )
+              .input-group-append
+                // This button actually does nothing, but vanilla js
+                // onChange might trigger only after the input is blurred
+                // on some browsers, unlike the default behavior in React
+                button(
+                  class='btn btn-primary'
+                  aria-label='save changes'
+                ) Save
 
   .container.mt-4
     br
@@ -102,7 +166,6 @@ block content
     div.alert.alert-secondary(style='background-color: #fbfbfb;')
       p Please copy the text in red and add it to your website, the code in this block updates automatically as you edit your widget.
       code(id='vbm-iframe-code')= env.REACT_APP_URL
-
 
     br
     h3 Preview
@@ -122,24 +185,40 @@ block content
     const code = document.getElementById('vbm-iframe-code');
     // The initial value of code is env.REACT_APP_URL (we can't access env here)
     const baseUrl = code.innerText;
+    let anchor = '';
+    let zip = '';
+
+    function updateCode() {
+      iframe.src = `${baseUrl}/${org}${anchor}${zip}`;
+      code.innerText = iframe.outerHTML;
+    }
 
     function setDimensions(w, h) {
       width = w;
       height = h;
       iframe.style.width = w;
       iframe.style.height = h;
-      code.innerText = iframe.outerHTML;
+      updateCode();
     }
 
     function setOrg(oid, clearInput) {
       org = `#/org/${oid ? oid : 'default'}`;
-      iframe.src = `${baseUrl}/${org}`;
-      code.innerText = iframe.outerHTML;
+      updateCode();
       if (clearInput) {
-        document.getElementById('vbm-iframe-org-input').value = ''
+        document.getElementById('vbm-iframe-org-input').value = '';
       }
     }
 
+    function setAnchor(a) {
+      anchor = a;
+      updateCode();
+    }
+
+    function setZip(z) {
+      zip = z ? `?postcode=${z}` : ''
+      updateCode();
+    }
+
     // Initialize default values
-    setDimensions(width, height)
-    setOrg(org)
+    setDimensions(width, height);
+    setOrg(org);

--- a/packages/server/src/service/static/pug/org.pug
+++ b/packages/server/src/service/static/pug/org.pug
@@ -69,6 +69,11 @@ block content
           small.text-muted.
             Visit Google's #[a(href='https://ga-dev-tools.appspot.com/campaign-url-builder/') campaign url bulder] for assistance building your own UTM url.
 
+        .card.mt-5.p-3
+          - var embedUrl = '/embed/' + richOrg.id
+          h4.text-primary Embed VoteByMail
+          p Get detailed #[a(href=embedUrl) instructions to Embed VoteByMail] via iFrame.
+
   .container.mt-5
     h4.text-primary Recent VBM Signups
     .d-flex.justify-content-between


### PR DESCRIPTION
- [x] Disable `localStorage` for embedded `iframe` windows;
- [x] Do needed changes on the backend/pug files;
- [x] Allows for organizers to select between multiple dimensions/orgs when iframing our website;
- [x] Create a flexible iframe, which expands to fill its parent size;
- [x] Create multiple startpoints for iframes, e.g. Team, Contact, Signup flow, etc;
- [x] Allows to prefill zipcode;

I was thinking, perhaps not necessarily in this in this PR, but maybe we could create a simpler version of our website (similar to that registration flow from Vote.Org) so organizers could use it? We'd still keep our branding/social links fixed somewhere in the iframe.

[Dashboard Preview](https://user-images.githubusercontent.com/31702297/91330544-f5ed3000-e79f-11ea-90b7-f929c7838ad1.png)