### PR TITLE
add user-variables to mailgun log denoting env and confirmation id

### DIFF
--- a/packages/server/src/service/trpc.ts
+++ b/packages/server/src/service/trpc.ts
@@ -127,7 +127,7 @@ export class VbmRpc implements ImplRpc<IVbmRpc, Request> {
         letter,
         info.email,
         method.emails,
-        { pdfBuffer },
+        { pdfBuffer, id },
       )
 
       // Upload PDF


### PR DESCRIPTION
I'd like to have this for when we import Mailgun logs into GCP so we can figure out which project's Stackdriver logs to write to