### PR TITLE
Removes unnecessary spacing on rendered letters

### DIFF
--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -1,5 +1,5 @@
 import { Letter } from '.'
-import { sampleStateInfo, sampleMethod } from './sample'
+import { sampleStateInfo, sampleMethod, sampleLetter } from './sample'
 import { implementedStates } from '../../common'
 
 beforeAll(() => jest.setTimeout(10000))
@@ -25,4 +25,15 @@ test('Letter for all states render correctly', async () => {
     */
     expect(letter?.md('html')).not.toContain('****')
   })
+})
+
+test('letter.md trims unnecessary empty lines without messing paragraphs', async () => {
+  const florida = await sampleLetter('Florida')
+  if (!florida) throw new Error('Test cannot be completed since sample letter is null')
+  const md = florida.md('html')
+
+  // We still want two consecutive empty lines, since these are paragraph breaks
+  expect(md.match(/(^( *)\n){2}/gm)).toBeTruthy()
+  // We'll never want to have 3 or more consecutive empy lines
+  expect(md.match(/(^( *)\n){3,}/gm)).toBeNull()
 })

--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -34,7 +34,7 @@ test('trimThreeOrMoreLines works as intended', () => {
 one empty line
 
 two empty lines
-\t\t\t
+
 
 four empty lines
 
@@ -53,34 +53,30 @@ four empty lines
 
  - Fourth item
 `
-  // Should replace three or more consecutive empty lines with just two,
-  // while preserving indentation/leading spaces of the next line, eg.:
-  //
-  // ```
-  // first line
-  //
-  //
-  //
-  //
-  //   - second line
-  // ```
-  //
-  // Should become:
-  // ```
-  // first line
-  //
-  //
-  //   - second line
-  // ```
-  const trimmed = trimThreeOrMoreLines(input)
 
-  // We still want two consecutive empty lines, since these are paragraph
-  // breaks, but never 3 or more empty consecutive lines
-  expect(trimmed.match(/(^(\s*)\n){2}/gm)).toBeTruthy()
-  expect(trimmed.match(/(^(\s*)\n){3,}/gm)).toBeNull()
+  const output =
+`zero empty lines
+one empty line
 
-  // Check if the right spacing is preserved after trimming
-  expect(trimmed.indexOf('\n - First item')).toBeGreaterThan(-1)
+two empty lines
+
+
+four empty lines
+
+
+ - First item
+
+
+ - Second item
+
+
+ - Third item
+
+
+ - Fourth item
+`
+
+  expect(trimThreeOrMoreLines(input)).toBe(output)
 })
 
 test('letter.md trims unnecessary empty lines without messing paragraphs', async () => {

--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -1,4 +1,4 @@
-import { Letter } from '.'
+import { Letter, trimThreeOrMoreLines } from '.'
 import { sampleStateInfo, sampleMethod, sampleLetter } from './sample'
 import { implementedStates } from '../../common'
 
@@ -27,13 +27,48 @@ test('Letter for all states render correctly', async () => {
   })
 })
 
+test('trimThreeOrMoreLines works as intended', () => {
+  // Remember that some empty lines have spaces over them
+  const input =
+`zero empty lines
+one empty line
+
+two empty lines
+\t\t\t
+
+four empty lines
+
+\t\t
+
+\t\t
+ - First item
+
+
+ - Second item
+
+\t
+              \t
+ - Third item
+
+
+ - Fourth item
+`
+  const trimmed = trimThreeOrMoreLines(input)
+
+  // We still want two consecutive empty lines, since these are paragraph
+  // breaks, but never 3 or more empty consecutive lines
+  expect(trimmed.match(/(^(\s*)\n){2}/gm)).toBeTruthy()
+  expect(trimmed.match(/(^(\s*)\n){3,}/gm)).toBeNull()
+
+  // Check if the right spacing is preserved on list items
+  expect(trimmed.indexOf('\n - First item')).toBeGreaterThan(-1)
+})
+
 test('letter.md trims unnecessary empty lines without messing paragraphs', async () => {
   const florida = await sampleLetter('Florida')
   if (!florida) throw new Error('Test cannot be completed since sample letter is null')
   const md = florida.md('html')
 
-  // We still want two consecutive empty lines, since these are paragraph breaks
-  expect(md.match(/(^( *)\n){2}/gm)).toBeTruthy()
-  // We'll never want to have 3 or more consecutive empy lines
-  expect(md.match(/(^( *)\n){3,}/gm)).toBeNull()
+  expect(md.match(/(^(\s*)\n){2}/gm)).toBeTruthy()
+  expect(md.match(/(^(\s*)\n){3,}/gm)).toBeNull()
 })

--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -53,6 +53,25 @@ four empty lines
 
  - Fourth item
 `
+  // Should replace three or more consecutive empty lines with just two,
+  // while preserving indentation/leading spaces of the next line, eg.:
+  //
+  // ```
+  // first line
+  //
+  //
+  //
+  //
+  //   - second line
+  // ```
+  //
+  // Should become:
+  // ```
+  // first line
+  //
+  //
+  //   - second line
+  // ```
   const trimmed = trimThreeOrMoreLines(input)
 
   // We still want two consecutive empty lines, since these are paragraph
@@ -60,7 +79,7 @@ four empty lines
   expect(trimmed.match(/(^(\s*)\n){2}/gm)).toBeTruthy()
   expect(trimmed.match(/(^(\s*)\n){3,}/gm)).toBeNull()
 
-  // Check if the right spacing is preserved on list items
+  // Check if the right spacing is preserved after trimming
   expect(trimmed.indexOf('\n - First item')).toBeGreaterThan(-1)
 })
 

--- a/packages/server/src/service/letter/index.test.ts
+++ b/packages/server/src/service/letter/index.test.ts
@@ -1,4 +1,4 @@
-import { Letter, trimThreeOrMoreLines } from '.'
+import { Letter, trimTwoOrMoreLines } from '.'
 import { sampleStateInfo, sampleMethod, sampleLetter } from './sample'
 import { implementedStates } from '../../common'
 
@@ -27,7 +27,7 @@ test('Letter for all states render correctly', async () => {
   })
 })
 
-test('trimThreeOrMoreLines works as intended', () => {
+test('trimTwoOrMoreLines works as intended', () => {
   // Remember that some empty lines have spaces over them
   const input =
 `zero empty lines
@@ -60,23 +60,18 @@ one empty line
 
 two empty lines
 
-
 four empty lines
-
 
  - First item
 
-
  - Second item
 
-
  - Third item
-
 
  - Fourth item
 `
 
-  expect(trimThreeOrMoreLines(input)).toBe(output)
+  expect(trimTwoOrMoreLines(input)).toBe(output)
 })
 
 test('letter.md trims unnecessary empty lines without messing paragraphs', async () => {
@@ -84,6 +79,10 @@ test('letter.md trims unnecessary empty lines without messing paragraphs', async
   if (!florida) throw new Error('Test cannot be completed since sample letter is null')
   const md = florida.md('html')
 
-  expect(md.match(/(^(\s*)\n){2}/gm)).toBeTruthy()
-  expect(md.match(/(^(\s*)\n){3,}/gm)).toBeNull()
+  // We still want to have single empty lines over the letters, since these
+  // are made of `\n\n` and represent a line break.
+  expect(md.match(/(^(\s*)\n){1}/gm)).toBeTruthy()
+  // We never want 2 or more consecutive empty lines, since these add undesired
+  // extra space.
+  expect(md.match(/(^(\s*)\n){2,}/gm)).toBeNull()
 })

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -116,7 +116,12 @@ export class Letter {
           ? `cid:${this.idPhotoAttachment.filename}`
           : this.info.idPhoto,
       },
-    ).replace(/((\n|( +)\n|\n( +)){3})+/g, '\n')
+      // Jinja will often use the whitespace in our views/*.md files, although
+      // possibly rendering a large amount of undesired empty lines. Albeit being
+      // possible to fix this by tweaking said files, it is much easier to
+      // use a regexp which looks for 3 or more consective empty lines and replaces them
+      // with just one.
+    ).replace(/(^( *)\n){3,}/gm, '\n')
   }
 
   /**

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -66,6 +66,17 @@ const template = (state: ImplementedState): string => {
   }
 }
 
+/**
+ * Jinja will often use the whitespace in our views/*.md files, rendering a
+ * large amount of undesired empty lines. Albeit being possible to fix this
+ * by tweaking said files, it is much easier to use a regexp which looks for
+ * 3 or more consective empty lines and replaces them with 2 empty lines
+ * (so paragraph breaks are still possible).
+ *
+ * @param s the content to be trimmed
+ */
+export const trimThreeOrMoreLines = (s: string) => s.replace(/(^( *)\n){3,}/gm, '\n\n')
+
 export class Letter {
   readonly confirmationId: string
   readonly subject: string
@@ -97,7 +108,7 @@ export class Letter {
    */
   md = (dest: 'email' | 'html') => {
     const method = this.method
-    return nunjucks.render(
+    const md = nunjucks.render(
       template(this.info.state),
       {
         ...this.info,
@@ -116,12 +127,9 @@ export class Letter {
           ? `cid:${this.idPhotoAttachment.filename}`
           : this.info.idPhoto,
       },
-      // Jinja will often use the whitespace in our views/*.md files, although
-      // possibly rendering a large amount of undesired empty lines. Albeit being
-      // possible to fix this by tweaking said files, it is much easier to
-      // use a regexp which looks for 3 or more consective empty lines and replaces them
-      // with two empty lines (so paragraph breaks are still possible).
-    ).replace(/(^( *)\n){3,}/gm, '\n\n')
+    )
+
+    return trimThreeOrMoreLines(md)
   }
 
   /**

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -120,8 +120,8 @@ export class Letter {
       // possibly rendering a large amount of undesired empty lines. Albeit being
       // possible to fix this by tweaking said files, it is much easier to
       // use a regexp which looks for 3 or more consective empty lines and replaces them
-      // with just one.
-    ).replace(/(^( *)\n){3,}/gm, '\n')
+      // with two empty lines (so paragraph breaks are still possible).
+    ).replace(/(^( *)\n){3,}/gm, '\n\n')
   }
 
   /**

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -116,7 +116,7 @@ export class Letter {
           ? `cid:${this.idPhotoAttachment.filename}`
           : this.info.idPhoto,
       },
-    )
+    ).replace(/((\n|( +)\n|\n( +)){3})+/g, '\n')
   }
 
   /**

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -75,7 +75,7 @@ const template = (state: ImplementedState): string => {
  *
  * @param s the content to be trimmed
  */
-export const trimThreeOrMoreLines = (s: string) => s.replace(/(^( *)\n){3,}/gm, '\n\n')
+export const trimThreeOrMoreLines = (s: string) => s.replace(/(^(\s*)\n){3,}/gm, '\n\n')
 
 export class Letter {
   readonly confirmationId: string

--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -70,12 +70,12 @@ const template = (state: ImplementedState): string => {
  * Jinja will often use the whitespace in our views/*.md files, rendering a
  * large amount of undesired empty lines. Albeit being possible to fix this
  * by tweaking said files, it is much easier to use a regexp which looks for
- * 3 or more consective empty lines and replaces them with 2 empty lines
+ * 2 or more consective empty lines and replaces them with 1 empty lines
  * (so paragraph breaks are still possible).
  *
  * @param s the content to be trimmed
  */
-export const trimThreeOrMoreLines = (s: string) => s.replace(/(^(\s*)\n){3,}/gm, '\n\n')
+export const trimTwoOrMoreLines = (s: string) => s.replace(/(^(\s*)\n){2,}/gm, '\n')
 
 export class Letter {
   readonly confirmationId: string
@@ -129,7 +129,7 @@ export class Letter {
       },
     )
 
-    return trimThreeOrMoreLines(md)
+    return trimTwoOrMoreLines(md)
   }
 
   /**


### PR DESCRIPTION
I did this using a regexp instead of manually tweaking .md files, results are attached below. More than 2 consecutive empty lines are converted to just one, 

[Arizona.md](https://github.com/vote-by-mail/website/files/5153570/Arizona.txt)
[Arizona.pdf](https://github.com/vote-by-mail/website/files/5153571/Arizona.pdf)

[all states md.zip](https://github.com/vote-by-mail/website/files/5153575/md.zip)
[all states pdf.zip](https://github.com/vote-by-mail/website/files/5153577/pdf.zip)

I could still try to work again on the .md files, so if that's the preferred way of solving this just let me know, thanks