### PR TITLE
Tries to remove node 14 from CI

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -7,43 +7,39 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 12
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '12.x'
 
     # Cache node_modules
     - name: Cache ~/.npm
       uses: actions/cache@v2
       with:
         path: ~/.npm  # npm cache files are stored in `~/.npm` on Linux/macOS
-        key: npm--${{ runner.os }}-${{ matrix.node-version }}
+        key: npm--${{ runner.os }}-Node12
     - name: cache node_modules/
       uses: actions/cache@v2
       with:
         path: node_modules
-        key: node-modules--${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+        key: node-modules--${{ runner.os }}-Node12-${{ hashFiles('yarn.lock') }}
     - name: cache packages/client/node_modules/
       uses: actions/cache@v2
       with:
         path: packages/client/node_modules
-        key: packages/client/node-modules--${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+        key: packages/client/node-modules--${{ runner.os }}-Node12-${{ hashFiles('yarn.lock') }}
     - name: cache packages/common/node_modules/
       uses: actions/cache@v2
       with:
         path: packages/common/node_modules
-        key: packages/common/node-modules--${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+        key: packages/common/node-modules--${{ runner.os }}-Node12-${{ hashFiles('yarn.lock') }}
     - name: cache packages/server/node_modules/
       uses: actions/cache@v2
       with:
         path: packages/server/node_modules
-        key: packages/server/node-modules--${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+        key: packages/server/node-modules--${{ runner.os }}-Node12-${{ hashFiles('yarn.lock') }}
     - name: cache packages/server/src/service/cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Maybe [this](https://github.community/t/workflow-file-not-updating-anymore/17333) is affecting us. I've just opened a new PR (https://github.com/ludanin/website/pull/1) in a fork of this repository, the changes are working as intended on the fork.

edit: Doesn't work by renaming or copying `node.yaml`