### PR TITLE
Allows embedded VBM to be rendered as modal

### DIFF
--- a/packages/client/gulpfile.js
+++ b/packages/client/gulpfile.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp')
+const csso = require('gulp-csso')
 const minimist = require('minimist')
 const run = require('@tianhuil/gulp-run-command').default
 const envs = require('../../env/env.js')
@@ -25,12 +26,20 @@ gulp.task('start',
   )
 )
 
+// compile public embed files
+gulp.task('embed', () => {
+  return gulp.src('./public/embed.css')
+    .pipe(csso())
+    .pipe(gulp.dest('./build'))
+})
+
 // build
 gulp.task('build', gulp.series(
   envRequired,
-  runEnv('react-app-rewired build')
+  runEnv('react-app-rewired build'),
+  'embed',
 ))
-  
+
 // test
 gulp.task('test', async () => {
   const watch = options.watch ? '' : '--watchAll=false'

--- a/packages/client/gulpfile.js
+++ b/packages/client/gulpfile.js
@@ -1,5 +1,6 @@
 const gulp = require('gulp')
 const csso = require('gulp-csso')
+const terser = require('gulp-terser')
 const minimist = require('minimist')
 const run = require('@tianhuil/gulp-run-command').default
 const envs = require('../../env/env.js')
@@ -27,10 +28,19 @@ gulp.task('start',
 )
 
 // compile public embed files
-gulp.task('embed', () => {
-  return gulp.src('./public/embed.css')
-    .pipe(csso())
-    .pipe(gulp.dest('./build'))
+gulp.task('embed', async () => {
+  await new Promise(
+    resolve => gulp.src('./public/embed.css')
+      .pipe(csso())
+      .pipe(gulp.dest('./build'))
+      .on('end', resolve())
+  )
+  await new Promise(
+    resolve => gulp.src('./public/embed.js')
+      .pipe(terser())
+      .pipe(gulp.dest('./build'))
+      .on('end', resolve())
+  )
 })
 
 // build

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,6 +33,7 @@
     "@types/styled-components": "^5.0.1",
     "@types/styled-react-modal": "^1.2.0",
     "gulp": "^4.0.2",
+    "gulp-csso": "^4.0.1",
     "jest-canvas-mock": "^2.2.0",
     "minimist": "^1.2.5",
     "node-sass": "^4.14.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,7 @@
     "@types/styled-react-modal": "^1.2.0",
     "gulp": "^4.0.2",
     "gulp-csso": "^4.0.1",
+    "gulp-terser": "^1.4.0",
     "jest-canvas-mock": "^2.2.0",
     "minimist": "^1.2.5",
     "node-sass": "^4.14.1",

--- a/packages/client/public/embed.css
+++ b/packages/client/public/embed.css
@@ -1,5 +1,4 @@
-/* When gulp runs task 'build' this file is automatically minified so */
-/* users never need to download all the comments/spacing below. */
+/* When gulp finishes task 'build' this file is automatically minified */
 
 *[class^="vote-by-mail"] {
   font-family: 'Open Sans', sans-serif;

--- a/packages/client/public/embed.css
+++ b/packages/client/public/embed.css
@@ -52,3 +52,85 @@
   width: 24px; height: 24px;
   margin-right: 8px;
 }
+
+/* Actions */
+
+.vote-by-mail__actions {
+  display: flex;
+}
+/* Shows close button when using modal */
+.vote-by-mail__modal .vote-by-mail__actions .modal-close {
+  display: inline-flex !important;
+}
+
+/* Bottom Button */
+
+.vote-by-mail__bottom-button {
+  background: none;
+  border: none;
+  margin: 0;
+  display: flex; align-items: center;
+}
+.vote-by-mail__bottom-button:focus {
+  outline: none;
+}
+
+.vote-by-mail__bottom-button:hover { cursor: pointer; }
+
+/* Transitions */
+.vote-by-mail__bottom-button { transition: fill .3s, color .3s; }
+.vote-by-mail__bottom-button:hover { fill: var(--primary); color: var(--primary); }
+
+/* Modal button */
+.vote-by-mail__modal-button {
+  width: 170px;
+  height: 50px;
+  font-size: 16px;
+  border: none;
+  border-radius: 4px;
+
+  background: none;
+  background-color: #fff;
+  box-shadow: 2px 2px 4px #0003;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.vote-by-mail__modal-button:hover { background-color: #fafafa; }
+.vote-by-mail__modal-button:active { background-color: #f1f1f1; }
+
+.vote-by-mail__modal-button img {
+  width: 20px; height: 20px;
+  margin-right: 8px;
+}
+
+/* Modal changes to the content */
+
+.vote-by-mail__modal {
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #0009;
+  width: 100vw;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+@keyframes vote-by-mail__modal-opening {
+  from { transform: translateY(-100%); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.vote-by-mail__modal .vote-by-mail__wrapper {
+  width: 95vw;
+  height: 80vh;
+  max-width: 1152px;
+  max-height: 700px;
+  animation: vote-by-mail__modal-opening .3s ease both;
+}
+
+.vote-by-mail__modal iframe { min-height: 400px !important; }

--- a/packages/client/public/embed.css
+++ b/packages/client/public/embed.css
@@ -1,0 +1,55 @@
+/* When gulp runs task 'build' this file is automatically minified so */
+/* users never need to download all the comments/spacing below. */
+
+*[class^="vote-by-mail"] {
+  font-family: 'Open Sans', sans-serif;
+}
+
+.vote-by-mail__wrapper {
+  --primary: #2193f9;
+  --danger: #dc0e52;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 3px 4px -2px #0003;
+  background-color: #fff;
+  border-radius: 4px;
+
+  /*
+    These are also set by iFrameResizer, just setting this here since
+    the .css file might load faster than the script when minified.
+  */
+  min-height: 600px;
+  min-width: 320px;
+}
+
+.vote-by-mail__wrapper iframe {
+  flex-grow: 1;
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+}
+
+/* Bottom bar shown below the iframe */
+.vote-by-mail__bottom-bar {
+  height: 50px;
+  border-top: 1px solid var(--danger);
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 0 20px;
+}
+
+.vote-by-mail__branding {
+  display: flex;
+  align-items: center;
+}
+.vote-by-mail__branding p { margin: 0; opacity: 0.5; transition: opacity ease .3s; }
+.vote-by-mail__branding p:hover { opacity: 1; }
+
+.vote-by-mail__branding img {
+  width: 24px; height: 24px;
+  margin-right: 8px;
+}

--- a/packages/client/public/embed.js
+++ b/packages/client/public/embed.js
@@ -1,0 +1,6 @@
+// This file's purpose is to hold all embed related functionalities in one
+// place.
+//
+// This file is automatically minified after gulp finishes task 'build'
+
+const vbmUtils = {}

--- a/packages/client/public/embed.js
+++ b/packages/client/public/embed.js
@@ -3,4 +3,34 @@
 //
 // This file is automatically minified after gulp finishes task 'build'
 
-const vbmUtils = {}
+const vbmUtils = {
+  modalVisible: false,
+  /**
+   * @param {string} url the initial destination of the modal
+   */
+  toggleModal(url) {
+    this.modalVisible = !this.modalVisible;
+
+    if (this.modalVisible) {
+      // Creates a div (modalWrapper) that fills the entire screen and a
+      // child for displaying the modal
+      const modalWrapper = document.createElement('div');
+      modalWrapper.id = 'vote-by-mail__modal';
+      modalWrapper.className = 'vote-by-mail__modal';
+      const modalContent = document.createElement('div');
+      modalContent.innerHTML = this.makeModalContent(url);
+
+      modalWrapper.appendChild(modalContent);
+      document.body.prepend(modalWrapper);
+    } else {
+      document.getElementById('vote-by-mail__modal').remove();
+    }
+  },
+
+  // Generates the raw HTML to be rendered by the modal, this is the same as
+  // the content generated for an iframe at embed.pug
+  makeModalContent(targetUrl) {
+    const appUrl = new URL(targetUrl).origin;
+    return `<link rel="stylesheet" href="${appUrl}/embed.css"><div class="vote-by-mail__wrapper"><iframe id="vbm-iframe" src="${targetUrl}" style="flex: 1 1 0%; overflow: auto; min-height: 600px; min-width: 320px;" marginheight="0" frameborder="0" scrolling="yes"></iframe><div class="vote-by-mail__bottom-bar"><div class="vote-by-mail__branding"><img src="${appUrl}/favicon-32x32.png"></div><div class="vote-by-mail__actions"><button class="vote-by-mail__bottom-button" onclick="vbmUtils.toggleTranslationDropdown()"><svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="8" height="8" viewBox="0 0 448 448" style="margin-right: 2px;"><path class="vote-by-mail__chevron"></path></svg><svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="14" height="16" viewBox="0 0 384 448"><path class="vote-by-mail__globe"></path></svg></button><button class="vote-by-mail__bottom-button modal-close" style="display: none;" onclick="vbmUtils.toggleModal()">✖</button></div></div><script type="text/javascript" src="${appUrl}/embed.js"></script><script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.3/iframeResizer.min.js"></script><script>iFrameResize({checkOrigin: false,scrolling: true,minHeight: 600,minWidth: 320,id:'vbm-iframe'});</script><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&amp;display=swap"></div>`;
+  }
+}

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -32,6 +32,11 @@ block content
                   value=state
                 )= state
 
+          h4.text-primary Modal
+          .form-check
+            input(type="checkbox" onChange='toggleAsModal()' name="Embed as modal" class="form-check-input")
+            label(for="Embed as modal" class="form-check-label") Embed as modal
+
         .col.col-md-6.col-sm-12.mt-3
           h4.text-primary Widget Code
           textarea(
@@ -45,8 +50,30 @@ block content
 
     br
     h3 Preview
+
+    //- We have two possible previews in this page, one for modal embeds
+    //- another for just embedded iframes, by default the page loads the
+    //- later and that's the reason of why we set `display: none` on the
+    //- modal preview (so only one preview is always shown). When users
+    //- toggle the modal option the script at the end of this pug file
+    //- updates which preview is rendered.
+
+    //- Embed modal preview
+    div(id='vbm-modal-preview')
+      link(rel='stylesheet', href=`${env.REACT_APP_URL}/embed.css`)
+      button(
+        class='vote-by-mail__modal-button'
+        id='vbm-modal-button'
+        style='display: none;'
+      )
+        img(src=`${env.REACT_APP_URL}/favicon-32x32.png`, alt="VoteByMail.io")
+        b Vote By Mail
+      script(type='text/javascript' src=`${env.REACT_APP_URL}/embed.js`)
+      link(rel="stylesheet", href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap")
+
+    //- Embed iframe preview
     div(
-      id='vbm-iframe-wrapper'
+      id='vbm-iframe-preview'
       style='width: 100%;'
     )
       link(rel='stylesheet' href=`${env.REACT_APP_URL}/embed.css`)
@@ -66,6 +93,14 @@ block content
           .vote-by-mail__branding
             img(src=`${env.REACT_APP_URL}/favicon-32x32.png`)
 
+          .vote-by-mail__actions
+            //- Close modal button
+            button(
+              style='display: none;'
+              class='vote-by-mail__bottom-button modal-close'
+              onClick='vbmUtils.toggleModal()'
+            ) &#10006;
+
 
         //- Scripts
         script(
@@ -82,15 +117,25 @@ block content
 
 
   script.
-    const iframeWrapper = document.getElementById('vbm-iframe-wrapper');
+    // We'll use the insides of the Previews to update the embed code
+    const modalPreview = document.getElementById('vbm-modal-preview');
+    const iframePreview = document.getElementById('vbm-iframe-preview');
+
+    // If users are opting for modals, the button that toggles VoteByMail modal
+    const modalButton = document.getElementById('vbm-modal-button');
+    // If users are opting for embeds, the actual iframe used in this page
     const iframe = document.getElementById('vbm-iframe');
+
+    // The element holding the embed code, which users can select to copy
     const code = document.getElementById('vbm-iframe-code');
+
     // The initial value of code is env.REACT_APP_URL + orgId (we can't access these here)
     const baseUrl = code.value;
     let state = '';
+    let modal = false;
 
-    // When the iframe loads it might scroll to the address form, stealing
-    // window focus, we don't want that.
+    // When the iframe loads/refreshes it might scroll to the address form,
+    // stealing window focus, we don't want that.
     let lockScroll = false;
     let lockScrollPosition = 0;
 
@@ -121,7 +166,24 @@ block content
       code.disabled = true;
     }
 
-    // scrollY must be a number, and if present it will lock scrolling the
+    // Updates the code used by embed modals
+    function updateModalCode() {
+      const targetUrl = `${baseUrl}${state}`
+      modalButton.onclick = function() {
+        vbmUtils.toggleModal(targetUrl);
+      }
+
+      // note that innerHTML/outerHTML does not save the onclick attribute,
+      // we'll need to manually add it back.
+      const newCode = modalPreview.innerHTML.replace(
+        '<button',
+        `<button onclick="vbmUtils.toggleModal('${targetUrl}')"`
+      );
+
+      code.value = newCode;
+    }
+
+    // scrollY can be a number, if present it will lock scrolling the
     // screen to the given position.
     function updateCode(scrollY) {
       // This is why our widget wasn't always updating, to see the changes
@@ -131,11 +193,16 @@ block content
       setTimeout(
         function() {
           iframe.src = `${baseUrl}${state}`;
-          code.value = iframeWrapper.innerHTML;
+          code.value = iframePreview.innerHTML;
           // we'll lock scrolling if scrollY is provided (when users change
-          // default states).
-          lockScroll = scrollY !== undefined
-          lockScrollPosition = scrollY
+          // default states). If users have selected to embed a modal this
+          // is not needed since the modal won't steal attention
+          if (!modal) {
+            lockScroll = scrollY !== undefined;
+            lockScrollPosition = scrollY;
+          } else {
+            updateModalCode();
+          }
         },
         50,
       );
@@ -145,6 +212,20 @@ block content
       anchor = '';
       state = s !== 'No default state' ? `/address/${s}` : '';
       updateCode(window.scrollY);
+    }
+
+    // Handles which preview to render in the page
+    function toggleAsModal() {
+      modal = !modal;
+      if (modal) {
+        iframePreview.style.display = 'none';
+        modalButton.style.display = 'flex';
+        updateModalCode();
+      } else {
+        iframePreview.style.display = 'initial';
+        modalButton.style.display = 'none';
+        updateCode();
+      }
     }
 
     // Initializes default values

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -45,26 +45,34 @@ block content
 
     br
     h3 Preview
-    p.text-muted The dashed red border does not appear in your embed.
     div(
       id='vbm-iframe-wrapper'
-      style='width: 100%; height: 1024px; border: 2px dashed #dc0e52;'
+      style='width: 100%;'
     )
-      iframe(
-        id='vbm-iframe'
-        src=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
-        width='100%'
-        height='100%'
-        marginheight='0'
-        frameborder='0'
-      )
-      script(
-        type='text/javascript'
-        src='//cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.3/iframeResizer.min.js'
-      )
-      //- More information about iFrameResize at
-      //- http://davidjbradshaw.github.io/iframe-resizer/
-      script iFrameResize({checkOrigin: false,scrolling: true,minHeight: 640,minWidth: 340,id: 'vbm-iframe'});
+      link(rel='stylesheet' href=`${env.REACT_APP_URL}/embed.css`)
+      .vote-by-mail__wrapper
+        //- Actual iframe
+        iframe(
+          id='vbm-iframe'
+          src=`${env.REACT_APP_URL}/#/org/${richOrg.id}`
+          width='100%'
+          height='100%'
+          marginheight='0'
+          frameborder='0'
+        )
+
+        //- Bottom bar
+        .vote-by-mail__bottom-bar
+          .vote-by-mail__branding
+            img(src=`${env.REACT_APP_URL}/favicon-32x32.png`)
+
+        script(
+          type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.3/iframeResizer.min.js'
+        )
+        //- More information about iFrameResize at
+        //- http://davidjbradshaw.github.io/iframe-resizer/
+        script iFrameResize({checkOrigin: false,scrolling: true,minHeight: 640,minWidth: 340,id: 'vbm-iframe'});
 
 
   script.

--- a/packages/server/src/service/static/pug/embed.pug
+++ b/packages/server/src/service/static/pug/embed.pug
@@ -66,6 +66,12 @@ block content
           .vote-by-mail__branding
             img(src=`${env.REACT_APP_URL}/favicon-32x32.png`)
 
+
+        //- Scripts
+        script(
+          type='text/javascript'
+          src=`${env.REACT_APP_URL}/embed.js`
+        )
         script(
           type='text/javascript'
           src='//cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.3/iframeResizer.min.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6663,7 +6663,7 @@ cssnano@^4.1.10:
     is-resolvable "^1.0.0"
     postcss "^7.0.0"
 
-csso@^4.0.2:
+csso@^4.0.0, csso@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/csso/-/csso-4.0.3.tgz#0d9985dc852c7cc2b2cacfbbe1079014d1a8e903"
   integrity sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==
@@ -9392,6 +9392,15 @@ gulp-cli@^2.2.0:
     semver-greatest-satisfied-range "^1.1.0"
     v8flags "^3.2.0"
     yargs "^7.1.0"
+
+gulp-csso@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-csso/-/gulp-csso-4.0.1.tgz#c2ac2b5f7138ed04073ed8f7cf89c12f716580d0"
+  integrity sha512-Kg8gqmd6XcUlMTdBbqdCEcpHumc8ytc4khgm9AXeCjl8eHx7b6tC11y8haizFI+Zw/cSHL6HCj7GwGLwxxBUFQ==
+  dependencies:
+    csso "^4.0.0"
+    plugin-error "^1.0.0"
+    vinyl-sourcemaps-apply "^0.2.1"
 
 gulp@^4.0.2:
   version "4.0.2"
@@ -14165,6 +14174,16 @@ plist@^3.0.1:
     xmlbuilder "^9.0.7"
     xmldom "0.1.x"
 
+plugin-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -16984,7 +17003,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -18826,6 +18845,13 @@ vinyl-sourcemap@^1.1.0:
     now-and-later "^2.0.0"
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
+
+vinyl-sourcemaps-apply@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
+  integrity sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=
+  dependencies:
+    source-map "^0.5.1"
 
 vinyl@^2.0.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9402,6 +9402,17 @@ gulp-csso@^4.0.1:
     plugin-error "^1.0.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
+gulp-terser@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gulp-terser/-/gulp-terser-1.4.0.tgz#0ac4dfdbed4ab46906007c5b358810c1642b9764"
+  integrity sha512-7df9leJna3WOmj76tYHxjpn7BSU+vmKVjVSd6bz3uLEyrzCfZI97KPhRcIabrSNzs0UY/UXTt+JwkxPw3sF85w==
+  dependencies:
+    is-promise "^4.0.0"
+    plugin-error "^1.0.1"
+    terser ">=4"
+    through2 "^4.0.2"
+    vinyl-sourcemaps-apply "^0.2.1"
+
 gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
@@ -10557,6 +10568,11 @@ is-promise@^2.0.0, is-promise@^2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -14174,7 +14190,7 @@ plist@^3.0.1:
     xmlbuilder "^9.0.7"
     xmldom "0.1.x"
 
-plugin-error@^1.0.0:
+plugin-error@^1.0.0, plugin-error@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
   integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
@@ -17769,6 +17785,15 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser@>=4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.0.tgz#c481f4afecdcc182d5e2bdd2ff2dc61555161e81"
+  integrity sha512-XTT3D3AwxC54KywJijmY2mxZ8nJiEjBHVYzq8l9OaYuRFWeQNBwvipuzzYEP4e+/AVcd1hqG/CqgsdIRyT45Fg==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
 terser@^4.1.2, terser@^4.4.3, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -17859,7 +17884,7 @@ through2@^3.0.0, through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through2@^4.0.0:
+through2@^4.0.0, through2@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
   integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==


### PR DESCRIPTION
Built on top of #161, suggested to be merged after #162

The greatest motivation behind this PR is to simplify organizers work on embedding VoteByMail. Since the modal will be rendered equally on most websites--with this PR site admins will be able to paste the code anywhere in their pages, ignoring the need to pay attention for space constraints.

The iFrameResizer works well when we now which dimensions the modal expects, but since we use the same code for mobile/desktop sizes there'll be pages where the mobile version might be used on big devices and vice-versa.

Button preview:
![button](https://user-images.githubusercontent.com/31702297/92315649-1cd90c80-efbf-11ea-84d9-34b6bdd88a26.png)

[Modal Preview](https://user-images.githubusercontent.com/31702297/92315695-febfdc00-efbf-11ea-8f17-afc1a226fa2c.png)

Preview these changes by downloading [this file (Remember to rename it to index.html)](https://github.com/vote-by-mail/website/files/5192227/index.html.txt)
