### PR TITLE
Properly returns errors on trpc.register

### DIFF
--- a/env/env.js
+++ b/env/env.js
@@ -71,7 +71,7 @@ const development = removeNullValues({
   GOOGLE_STORAGE_BUCKET: 'vbm-dev-281822.appspot.com',
   DEV_SERVER_PORT: 8080,
   REACT_APP_DEFAULT_ADDRESS: 1,
-  REACT_APP_TIMEOUT: 2000,
+  REACT_APP_TIMEOUT: 10000,
   DEV_EMAIL: 'email@example.com',
   NUNJUNKS_DISABLE_CACHE: 1,
   REACT_APP_MOCK: 1,
@@ -146,7 +146,7 @@ const test = removeNullValues((() => {
     FIRESTORE_URL: 'http://localhost:8081',  // for e2e tests with firestore emulator
     NODE_ENV: 'test',
     REACT_APP_SERVER: 'https://example.com',
-    REACT_APP_TIMEOUT: 2000,
+    REACT_APP_TIMEOUT: 10000,
     FIRESTORE_EMULATOR_HOST: 'localhost:8081',
     MG_DISABLE: 1,
     TWILIO_DISABLE: 1,

--- a/packages/server/src/service/signup.ts
+++ b/packages/server/src/service/signup.ts
@@ -1,0 +1,58 @@
+import { StateInfo, ContactMethod } from '../common'
+import { Letter } from './letter'
+import { toPdfBuffer } from './pdf'
+import { sendSignupEmail } from './mg'
+import { FirestoreService } from './firestore'
+import { storageFileFromId } from './storage'
+import { TwilioResponse } from './types'
+import { sendFaxes } from './twilio'
+const firestoreService = new FirestoreService()
+
+/**
+ * Sends and store signups, returning true if the entire process was completed
+ * without errors, and false otherwise.
+ */
+export const sendAndStoreSignup = async (
+  info: StateInfo,
+  method: ContactMethod,
+  id: string,
+): Promise<boolean> => {
+  const letter = new Letter(info, method, id)
+  const pdfBuffer = await toPdfBuffer(letter.render('html'), await letter.form)
+
+  // Send email (perhaps only to voter)
+  const mgResponse = await sendSignupEmail(
+    letter,
+    info.email,
+    method.emails,
+    { pdfBuffer, id },
+  )
+  if (!mgResponse || mgResponse.message !== 'Queued. Thank you.') {
+    console.error('Error sending email for ' + info.id + '.')
+    console.error(mgResponse)
+    return false
+  }
+
+  // Upload PDF
+  const file = storageFileFromId(id)
+  await file.upload(pdfBuffer)
+
+  // Send faxes
+  let twilioResponses: TwilioResponse[] = []
+  if (method.faxes.length > 0) {
+    const uri = await file.getSignedUrl(24 * 60 * 60 * 1000)
+    const resposnes = await sendFaxes(uri, method.faxes)
+    twilioResponses = resposnes.map(({url, sid, status}) => ({url, sid, status}))
+
+    for (const twilioResponse of twilioResponses) {
+      if (twilioResponse.status !== "queued") {
+        console.error(`Error sending faxes for ${info.id ?? id}.`)
+        console.error(twilioResponse)
+        return false
+      }
+    }
+  }
+
+  await firestoreService.updateRegistration(id, mgResponse, twilioResponses)
+  return true
+}

--- a/packages/server/src/service/trpc.test.ts
+++ b/packages/server/src/service/trpc.test.ts
@@ -5,11 +5,13 @@ import { Request } from 'express'
 import { sendFaxes as unmockedSendFaxes } from './twilio'
 import { isE164 } from '../common'
 import { createMock } from 'ts-auto-mock'
+import { sendSignupEmail } from './mg'
 
 // To avoid doing actual requests (and setting a lot of new envs for tests),
 // we mock the majority of functions/modules related to trpc.
 
 jest.mock('./mg')
+mocked(sendSignupEmail).mockResolvedValue({ message: 'Queued. Thank you.', id: 'foobar' })
 jest.mock('./twilio')
 jest.mock('./firestore')
 jest.mock('./pdf')
@@ -44,10 +46,7 @@ test('trpc.register uses e164 number on sendFaxes', async () => {
       remoteAddress: '127.0.0.1',
     }
   })
-  const res = await trpc.register(stateInfo, { uid: 'abcdefghij' }, req)
-  // Ensures res.data is processed
-  const cont = res?.continuation as () => Promise<void>
-  await cont()
+  await trpc.register(stateInfo, { uid: 'abcdefghij' }, req)
 
   expect(sendFaxes).toHaveBeenCalledTimes(1)
   // [ [ 'url', [ '+12078763198' ] ] ]

--- a/packages/server/src/service/trpc.ts
+++ b/packages/server/src/service/trpc.ts
@@ -3,16 +3,12 @@ import { ImplRpc } from '@tianhuil/simple-trpc/dist/type'
 import { Request } from 'express'
 import { IVbmRpc, StateInfo, toLocale, toContactMethod, isState, Voter, Locale, ImplementedState, RegistrationArgs, AddressInputParts } from '../common'
 import { FirestoreService } from './firestore'
-import { sendSignupEmail, mg } from './mg'
+import { mg } from './mg'
 import { toContact, contactRecords, getContact as _getContact } from './contact'
 import { geocode, zipSearch } from './gm'
-import { toPdfBuffer } from './pdf'
-import { storageFileFromId } from './storage'
-import { Letter } from './letter'
-import { sendFaxes } from './twilio'
-import { TwilioResponse } from './types'
 import { sib } from './sendinblue'
 import { isRegistered } from './alloy'
+import { sendAndStoreSignup } from './signup'
 
 const firestoreService = new FirestoreService()
 
@@ -119,31 +115,9 @@ export class VbmRpc implements ImplRpc<IVbmRpc, Request> {
       method,
     })
 
-    return data(id, async (): Promise<void> => {
-      const letter = new Letter(info, method, id)
-      const pdfBuffer = await toPdfBuffer(letter.render('html'), await letter.form)
-
-      // Send email (perhaps only to voter)
-      const mgResponse = await sendSignupEmail(
-        letter,
-        info.email,
-        method.emails,
-        { pdfBuffer, id },
-      )
-
-      // Upload PDF
-      const file = storageFileFromId(id)
-      await file.upload(pdfBuffer)
-
-      // Send faxes
-      let twilioResponses: TwilioResponse[] = []
-      if (method.faxes.length > 0) {
-        const uri = await file.getSignedUrl(24 * 60 * 60 * 1000)
-        const resposnes = await sendFaxes(uri, method.faxes)
-        twilioResponses = resposnes.map(({url, sid, status}) => ({url, sid, status}))
-      }
-
-      await firestoreService.updateRegistration(id, mgResponse, twilioResponses)
-    })
+    const success = await sendAndStoreSignup(info, method, id)
+    return success
+      ? data(id)
+      : error('Failed to register voter')
   }
 }


### PR DESCRIPTION
Did this mainly because of #171, refactored into a separate file because of #133 (so we don't have to handle more conflicts when merging it)

The explanation behind these changes is found on #171:

>Something I noticed when doing this PR: trpc.register doesn't really handle failures and always returns data, so if MG fails to send an email but don't throw an error we can't really log these.
>
>To keep this PR [#171] short I'll be opening a new one addressing this (I'll leave this PR [#171] assigned for me until we merge the fix).