### PR TITLE
Improves Minnesota UX

### DIFF
--- a/packages/client/src/comp/states/Minnesota.tsx
+++ b/packages/client/src/comp/states/Minnesota.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
 
-import { Select } from '../util/Select'
 import { MinnesotaInfo, minnesotaIdentityType, MinnesotaIdentityType } from '../../common'
 import { SignatureBase, StatelessInfo, NoSignature } from './Base'
 import { BaseInput } from '../util/Input'
+import { TogglableDropdown } from '../util/TogglableDropdown'
+import { AppCheckbox } from '../util/Checkbox'
 
 export const Minnesota = () => {
   const [ idType, setIdType ] = React.useState<MinnesotaIdentityType>('Last 4 numbers of SSN')
   const [ idData, setIdData ] = React.useState<string>('')
 
   const enrichValues = (baseInfo: StatelessInfo): NoSignature<MinnesotaInfo> | null => {
-    if (!idData) return null
+    if (!idData && idType !== 'None') return null
 
     return {
       ...baseInfo,
@@ -22,24 +23,29 @@ export const Minnesota = () => {
 
   return <SignatureBase<MinnesotaInfo>enrichValues={enrichValues}>
     <p>Minnesota requires voters to confirm their identify using one of the following types of identification</p>
-    <Select
+    <TogglableDropdown
       label='Identification Type'
       value={idType}
       options={minnesotaIdentityType}
       onChange={v => setIdType(v)}
-    />
-    <p>Enter the relevant information based on your choice above.  If &apos;None&apos;
-      please confirm by typing &apos;None&apos;:
-    </p>
-    <BaseInput
-      id='identityData'
-      label='Identity Information'
-      value={idData}
-      onChange={e => setIdData(e.currentTarget.value)}
-      required={true}
-      // HTML patterns are never case insensitive, manually creating a regexp
-      // that allows users to ignore case here
-      pattern={idType === 'None' ? '^(\\s*)(N|n)(O|o)(N|n)(E|e)(\\s*)$' : undefined}
-    />
+    >{(option) => {
+      switch (option) {
+        case 'Minnesota Issued Driver\'s License or ID Card':
+        case 'Last 4 numbers of SSN':
+          return <BaseInput
+            id='identityData'
+            label='Identity Information'
+            value={idData}
+            onChange={e => setIdData(e.currentTarget.value)}
+            required={true}
+          />
+
+        default:
+          return <AppCheckbox
+            label={'You confirm to be sending no Identity Information'}
+            required={true}
+          />
+      }
+    }}</TogglableDropdown>
   </SignatureBase>
 }

--- a/packages/client/src/comp/states/Minnesota.tsx
+++ b/packages/client/src/comp/states/Minnesota.tsx
@@ -40,7 +40,7 @@ export const Minnesota = () => {
             required={true}
           />
 
-        default:
+        case 'None':
           return <AppCheckbox
             label={'I confirm that I do not have a Minnesota-issued driver’s license, Minnesota-issued ID card or a social security number'}
             required={true}

--- a/packages/client/src/comp/states/Minnesota.tsx
+++ b/packages/client/src/comp/states/Minnesota.tsx
@@ -42,7 +42,7 @@ export const Minnesota = () => {
 
         default:
           return <AppCheckbox
-            label={'You confirm to be sending no Identity Information'}
+            label={'I confirm that I do not have a Minnesota-issued driver’s license, Minnesota-issued ID card or a social security number'}
             required={true}
           />
       }


### PR DESCRIPTION
Built on top of #174, basically this PR works on this idea:

> [..] replace this input [to type 'None' to confirm no ID] with a `<TogglableDropdown/>` (like we did with Kansas), and ask users to fill a checkbox to confirm when sending with no identifications.