### PR TITLE
Tracks per-org data on the analytics

### DIFF
--- a/packages/server/src/analytics/logic.ts
+++ b/packages/server/src/analytics/logic.ts
@@ -1,8 +1,8 @@
 import { AnalyticsStorageSchema, AnalyticsMetricPair } from "./storage"
 import { RichStateInfo } from "../service/types"
 
-const notRepeated = (entryTimeSeconds: number, lastQueryTimeMillis: number) => {
-  return entryTimeSeconds >= (lastQueryTimeMillis / 1000)
+const notRepeated = (entryTimeMillis: number, lastQueryTimeMillis: number) => {
+  return entryTimeMillis >= lastQueryTimeMillis
 }
 
 const incrementMetricPair = <S extends Record<string, AnalyticsMetricPair>>(

--- a/packages/server/src/analytics/updateTimeSeries.ts
+++ b/packages/server/src/analytics/updateTimeSeries.ts
@@ -109,7 +109,8 @@ export const updateTimeSeries = async () => {
   for (const org of Object.keys(newValues.org.values)) {
     const orgData = newValues.org.values[org]
     if (orgData) {
-      await updateMetric(org, orgData.todaySignups, orgData.totalSignups, now)
+      // Prefixing 'org_' before oid in case we have entries with oid like 'az' or 'fl'
+      await updateMetric(`org_${org}`, orgData.todaySignups, orgData.totalSignups, now)
     }
   }
 


### PR DESCRIPTION
- [x] It's impossible to manually create a dashboard for tracking all orgs daily/total sign ups, find a way to create the dashboard from the API (Opening a new PR for this);
- [x] Test to see if these changes works;
- [x] Fix the tests for these changes;