### PR TITLE
Increases app memory

### DIFF
--- a/packages/server/app.tmpl.yaml
+++ b/packages/server/app.tmpl.yaml
@@ -1,6 +1,6 @@
 runtime: nodejs12
 
-instance_class: F2
+instance_class: F4
 automatic_scaling:
   min_instances: 1
   min_idle_instances: automatic


### PR DESCRIPTION
This might fix the issue currently happening when performing big downloads in the back-end.

Remember to run `yarn server gulp appsubst --env production`

Note that we're increasing the memory to 1gb, this might not be enough if the organization has more than 1k signups where each has more than 1mb in disk space--then if we try with 2gb and doesn't solve the issue it's not a memory problem

https://console.cloud.google.com/logs/query;pinnedLogId=2020-10-11T22:17:31.897913Z%2F5f83847b000db37991e1bc5a;query=?project=vbm-prod-281822